### PR TITLE
docs: expand README with setup and roadmap details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
 # 3dmodel
-3d
+
+A lightweight 3D model viewer intended for quick prototyping and demonstrations. The project focuses on delivering an interactive scene that works well across desktop and touch devices while keeping the build pipeline simple.
+
+## Tech Stack
+- **Vite + React** for a fast development server and component-driven UI composition.
+- **TypeScript** to provide static typing and safer refactoring as the viewer grows.
+- **Three.js** for rendering WebGL scenes and handling camera, lighting, and mesh utilities.
+- **ESLint & Prettier** (optional) for consistent formatting and linting when added to the toolchain.
+
+## License
+This project is intended to be released under the MIT License. Add a `LICENSE` file with the full text before distributing binaries or builds.
+
+## Getting Started
+Install dependencies, start the development server, or build the optimized production bundle:
+
+```bash
+npm install
+npm run dev
+npm run build
+```
+
+## Usage Notes
+- Load supported `.glb`/`.gltf` assets through the UI or by updating the default asset path.
+- Use the camera controls below to inspect geometry from multiple angles.
+- Ensure textures are hosted alongside models when deploying to avoid CORS errors.
+
+### Touch Gesture Guide
+- **Single finger drag**: Orbit around the focal point.
+- **Two finger drag**: Pan across the scene.
+- **Pinch**: Zoom in or out, matching mouse scroll behavior.
+
+### Keyboard Shortcuts
+- `W` / `S`: Dolly the camera forward or backward.
+- `A` / `D`: Strafe left or right.
+- `Q` / `E`: Roll the camera counterclockwise or clockwise.
+- `R`: Reset the camera to its default position.
+- `Space`: Toggle animation playback.
+
+## Architecture Overview
+```
++---------------------+
+|  React Components   |  UI panels, loaders, overlays
++----------+----------+
+           |
+           v
++----------+----------+
+| Scene Controller    |  Hooks binding UI state to Three.js scene
++----------+----------+
+           |
+           v
++----------+----------+
+| Three.js Renderer   |  Cameras, lights, and render loop
++----------+----------+
+           |
+           v
++---------------------+
+| Asset Pipeline      |  Loader utilities for GLTF/texture assets
++---------------------+
+```
+
+## Deployment
+The project is designed for static hosting, such as GitHub Pages or Netlify. Run `npm run build` to produce the `dist/` directory, then upload the contents to your hosting provider. Set the base path appropriately (e.g., `vite.config.ts > base`) when deploying to a subdirectory.
+
+### Automation & Workflows
+At present there are no CI/CD pipelines or deployment workflows defined in this repository. If you adopt GitHub Pages, consider adding a GitHub Actions workflow (for example, `.github/workflows/deploy.yml`) that runs `npm install`, `npm run build`, and publishes the `dist/` folder automatically.
+
+## Roadmap
+- [ ] Add automated GitHub Actions build-and-deploy pipeline.
+- [ ] Provide drag-and-drop asset upload directly in the UI.
+- [ ] Expand material editing panel with presets and real-time previews.
+- [ ] Integrate unit tests for scene helpers and UI state management.
+- [ ] Document environment configuration for bundling large assets.
+


### PR DESCRIPTION
## Summary
- expand the README with sections for the tech stack, licensing information, and installation commands
- document usage details including touch gestures, keyboard shortcuts, and an ASCII architecture overview
- outline deployment guidance, note the absence of automation workflows, and add a roadmap of future enhancements

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e26620dd408327bb3de7e8c7332df7