### PR TITLE
Add CI workflow and deployment automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # 3dmodel
-3d
+
+This repository now ships with a minimal Node-based toolchain so you can automate
+builds and deployment while the actual 3D experience is under construction.
+
+## Continuous integration
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs `npm install` and
+`npm run build` on every push and pull request. Use this to keep the build
+healthy as new assets and code are added.
+
+## Building locally
+
+```bash
+npm install
+npm run build
+```
+
+The default build script writes a placeholder HTML file to `dist/index.html`.
+Swap `scripts/build.js` for your real bundler when the project is ready.
+
+## One-click deployment
+
+Deploy to GitHub Pages with a single command once you have committed your
+changes:
+
+```bash
+npm run deploy
+```
+
+The deploy script rebuilds the site and publishes the contents of `dist/` to the
+`gh-pages` branch via the [`gh-pages`](https://www.npmjs.com/package/gh-pages)
+CLI.
+
+> **Tip:** Update the build script or replace it with your production build
+> pipeline before your first deployment so the published site reflects the real
+> project output.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "3dmodel",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Automation scaffolding for the 3dmodel project.",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "deploy": "npm run build && npx gh-pages -d dist --dotfiles"
+  },
+  "devDependencies": {
+    "gh-pages": "^6.0.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '..', 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3dmodel</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, #ffffff, #dfe4ea);
+        color: #1f2933;
+      }
+      main {
+        padding: 3rem;
+        max-width: 48rem;
+        text-align: center;
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 1rem;
+        box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+      }
+      h1 {
+        font-size: clamp(2.5rem, 6vw, 3.5rem);
+        margin-bottom: 1rem;
+      }
+      p {
+        font-size: clamp(1rem, 2.5vw, 1.125rem);
+        line-height: 1.6;
+      }
+      code {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.5rem;
+        background-color: rgba(59, 130, 246, 0.1);
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>3dmodel</h1>
+      <p>
+        The build pipeline is ready! Replace <code>scripts/build.js</code> with your
+        actual application bundler so that <code>npm run build</code> exports the
+        production-ready site to <code>dist/</code>.
+      </p>
+    </main>
+  </body>
+</html>`;
+
+fs.writeFileSync(path.join(distDir, 'index.html'), html, 'utf8');
+
+console.log('dist/index.html generated. Replace scripts/build.js with your actual build.');


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs the Node build
- introduce a minimal Node toolchain with placeholder build output and a gh-pages deploy command
- document the CI and one-command deployment process in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e26620285c83278471413a407132c9