### PR TITLE
chore: replace png icons with svg

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.dist
+.vite
+.DS_Store
+*.log
+pnpm-lock.yaml
+yarn.lock
+dist
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icons/icon-192.svg" type="image/svg+xml" />
+    <title>3D Modeler</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "3dmodeler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "three": "^0.162.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.2",
+    "vite": "^5.1.0"
+  }
+}

--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="32" fill="#0f172a" />
+  <path d="M48 132L96 60l48 72" fill="none" stroke="url(#grad)" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="96" cy="128" r="18" fill="url(#grad)" />
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad512" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="#0f172a" />
+  <path d="M128 360L256 168l128 192" fill="none" stroke="url(#grad512)" stroke-width="48" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="256" cy="344" r="48" fill="url(#grad512)" />
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "3D Modeler",
+  "short_name": "3DModeler",
+  "display": "standalone",
+  "start_url": ".",
+  "background_color": "#111111",
+  "theme_color": "#1d4ed8",
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sample.gltf
+++ b/public/sample.gltf
@@ -1,0 +1,73 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Handauthored"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "name": "Triangle"
+    }
+  ],
+  "meshes": [
+    {
+      "name": "TriangleMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1
+        }
+      ]
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [
+        1,
+        1,
+        0
+      ],
+      "min": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 36
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 36,
+      "byteLength": 6
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAABAAIA",
+      "byteLength": 42
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = '3dmodeler-cache-v1';
+const OFFLINE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest'
+];
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
+  );
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) =>
+      cached || fetch(event.request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      }).catch(() => caches.match('/index.html'))
+    )
+  );
+});

--- a/src/core/GestureController.ts
+++ b/src/core/GestureController.ts
@@ -1,0 +1,103 @@
+import { Box3, Mesh, Object3D, Vector3 } from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { RendererManager } from './RendererManager';
+import { GizmoManager } from './GizmoManager';
+import { SceneManager } from './SceneManager';
+
+export class GestureController {
+  readonly controls: OrbitControls;
+  private pointerDown = { x: 0, y: 0, time: 0 };
+  private pointerMoved = false;
+  private defaultPosition: Vector3;
+  private box = new Box3();
+  private vec = new Vector3();
+
+  constructor(
+    private rendererManager: RendererManager,
+    private gizmoManager: GizmoManager,
+    private sceneManager: SceneManager
+  ) {
+    this.defaultPosition = rendererManager.camera.position.clone();
+    this.controls = new OrbitControls(rendererManager.camera, rendererManager.domElement);
+    this.controls.enableDamping = true;
+    this.controls.enablePan = true;
+    this.controls.maxPolarAngle = Math.PI * 0.98;
+    this.controls.minDistance = 0.5;
+    this.controls.maxDistance = 200;
+    this.controls.target.set(0, 0.5, 0);
+    this.controls.update();
+    this.rendererManager.onFrame(() => this.controls.update());
+
+    this.rendererManager.domElement.addEventListener('pointerdown', this.onPointerDown);
+    this.rendererManager.domElement.addEventListener('pointerup', this.onPointerUp);
+    this.rendererManager.domElement.addEventListener('pointermove', this.onPointerMove);
+    this.rendererManager.domElement.addEventListener('wheel', () => this.controls.update(), { passive: true });
+  }
+
+  dispose() {
+    this.controls.dispose();
+    this.rendererManager.domElement.removeEventListener('pointerdown', this.onPointerDown);
+    this.rendererManager.domElement.removeEventListener('pointerup', this.onPointerUp);
+    this.rendererManager.domElement.removeEventListener('pointermove', this.onPointerMove);
+  }
+
+  resetCamera() {
+    const camera = this.rendererManager.camera;
+    camera.position.copy(this.defaultPosition);
+    this.controls.target.set(0, 0.5, 0);
+    this.controls.update();
+  }
+
+  focusOn(object?: Object3D | null) {
+    if (!object) {
+      this.resetCamera();
+      return;
+    }
+    const camera = this.rendererManager.camera;
+    this.box.setFromObject(object);
+    const center = this.box.getCenter(this.vec);
+    if (!isFinite(center.lengthSq())) {
+      this.resetCamera();
+      return;
+    }
+    const size = this.box.getSize(this.vec).length();
+    const distance = Math.max(size, 1.5) / Math.tan((camera.fov * Math.PI) / 360);
+    const direction = camera.position.clone().sub(this.controls.target).normalize();
+    if (!isFinite(direction.length())) {
+      direction.set(0, 0, 1);
+    }
+    camera.position.copy(center.clone().add(direction.multiplyScalar(distance)));
+    this.controls.target.copy(center);
+    this.controls.update();
+  }
+
+  private onPointerDown = (event: PointerEvent) => {
+    this.pointerDown = { x: event.clientX, y: event.clientY, time: performance.now() };
+    this.pointerMoved = false;
+  };
+
+  private onPointerMove = (event: PointerEvent) => {
+    if (Math.hypot(event.clientX - this.pointerDown.x, event.clientY - this.pointerDown.y) > 6) {
+      this.pointerMoved = true;
+    }
+  };
+
+  private onPointerUp = (event: PointerEvent) => {
+    if (this.gizmoManager.isTransforming()) {
+      return;
+    }
+    const elapsed = performance.now() - this.pointerDown.time;
+    const distance = Math.hypot(event.clientX - this.pointerDown.x, event.clientY - this.pointerDown.y);
+    if (elapsed < 300 && distance < 6 && !this.pointerMoved) {
+      const intersections = this.rendererManager.pick(event.clientX, event.clientY);
+      const hit = intersections.find((intersection) => intersection.object.visible && intersection.object instanceof Mesh);
+      if (hit) {
+        this.sceneManager.select(hit.object);
+        this.gizmoManager.attach(hit.object);
+      } else {
+        this.sceneManager.select(null);
+        this.gizmoManager.detach();
+      }
+    }
+  };
+}

--- a/src/core/GizmoManager.ts
+++ b/src/core/GizmoManager.ts
@@ -1,0 +1,64 @@
+import { Object3D, PerspectiveCamera } from 'three';
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import { SceneManager } from './SceneManager';
+import { UndoStack } from './UndoStack';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+export type TransformMode = 'translate' | 'rotate' | 'scale';
+
+export class GizmoManager {
+  private controls: TransformControls;
+  private active = false;
+  private orbitControls?: OrbitControls;
+  private current?: Object3D | null;
+
+  constructor(
+    private sceneManager: SceneManager,
+    camera: PerspectiveCamera,
+    domElement: HTMLElement,
+    private undoStack: UndoStack
+  ) {
+    this.controls = new TransformControls(camera, domElement);
+    this.controls.setSize(1.1);
+    this.controls.addEventListener('dragging-changed', (event) => {
+      this.active = event.value;
+      if (this.orbitControls) {
+        this.orbitControls.enabled = !event.value;
+      }
+      if (!event.value) {
+        void this.undoStack.capture();
+        this.sceneManager.notifyChange();
+      }
+    });
+    this.controls.addEventListener('mouseDown', () => {
+      void this.undoStack.capture();
+    });
+    this.sceneManager.scene.add(this.controls);
+  }
+
+  registerOrbitControls(controls: OrbitControls) {
+    this.orbitControls = controls;
+  }
+
+  setMode(mode: TransformMode) {
+    this.controls.setMode(mode);
+  }
+
+  attach(object: Object3D) {
+    this.current = object;
+    this.controls.attach(object);
+  }
+
+  detach() {
+    this.current = null;
+    this.controls.detach();
+  }
+
+  isTransforming() {
+    return this.active;
+  }
+
+  get currentObject() {
+    return this.current;
+  }
+}

--- a/src/core/RendererManager.ts
+++ b/src/core/RendererManager.ts
@@ -1,0 +1,87 @@
+import { Clock, PerspectiveCamera, Raycaster, Scene, Vector2, WebGLRenderer } from 'three';
+import { SceneManager } from './SceneManager';
+
+export class RendererManager {
+  readonly renderer: WebGLRenderer;
+  readonly camera: PerspectiveCamera;
+  readonly scene: Scene;
+  readonly raycaster = new Raycaster();
+  private pointer = new Vector2();
+  private clock = new Clock();
+  private animationId: number | null = null;
+  private container?: HTMLElement;
+  private frameCallbacks = new Set<() => void>();
+
+  constructor(private sceneManager: SceneManager) {
+    this.scene = sceneManager.scene;
+    this.camera = sceneManager.camera;
+    this.renderer = new WebGLRenderer({ antialias: true, alpha: true });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.domElement.style.touchAction = 'none';
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  get domElement() {
+    return this.renderer.domElement;
+  }
+
+  mount(container: HTMLElement) {
+    this.container = container;
+    this.container.innerHTML = '';
+    this.container.appendChild(this.renderer.domElement);
+    this.resize();
+    this.start();
+  }
+
+  unmount() {
+    this.stop();
+    this.renderer.dispose();
+  }
+
+  resize() {
+    const width = this.container?.clientWidth ?? window.innerWidth;
+    const height = this.container?.clientHeight ?? window.innerHeight;
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height);
+  }
+
+  start() {
+    if (this.animationId !== null) return;
+    const loop = () => {
+      const delta = this.clock.getDelta();
+      void delta;
+      for (const callback of this.frameCallbacks) {
+        callback();
+      }
+      this.render();
+      this.animationId = requestAnimationFrame(loop);
+    };
+    loop();
+  }
+
+  stop() {
+    if (this.animationId !== null) {
+      cancelAnimationFrame(this.animationId);
+      this.animationId = null;
+    }
+  }
+
+  render() {
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  pick(clientX: number, clientY: number) {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    this.pointer.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    this.pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+    this.raycaster.setFromCamera(this.pointer, this.camera);
+    return this.raycaster.intersectObjects(this.scene.children, true);
+  }
+
+  onFrame(callback: () => void) {
+    this.frameCallbacks.add(callback);
+    return () => this.frameCallbacks.delete(callback);
+  }
+}

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -1,0 +1,234 @@
+import {
+  AmbientLight,
+  BoxGeometry,
+  Color,
+  DirectionalLight,
+  Mesh,
+  MeshStandardMaterial,
+  Object3D,
+  PerspectiveCamera,
+  PlaneGeometry,
+  Scene,
+  SphereGeometry
+} from 'three';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+export type PrimitiveType = 'box' | 'sphere' | 'plane';
+
+export interface SceneEventMap {
+  selection: Object3D | null;
+  change: void;
+}
+
+export type SceneEventListener<K extends keyof SceneEventMap> = (payload: SceneEventMap[K]) => void;
+
+let objectId = 0;
+
+export class SceneManager {
+  readonly scene = new Scene();
+  readonly camera = new PerspectiveCamera(60, 1, 0.1, 1000);
+  private selected: Object3D | null = null;
+  private listeners: { [K in keyof SceneEventMap]: SceneEventListener<K>[] } = {
+    selection: [],
+    change: []
+  };
+  private loader = new GLTFLoader();
+  private exporter = new GLTFExporter();
+
+  constructor() {
+    this.scene.background = new Color('#020617');
+
+    const ambient = new AmbientLight('#f1f5f9', 0.6);
+    ambient.name = 'Ambient Light';
+    const directional = new DirectionalLight('#f8fafc', 1.1);
+    directional.name = 'Main Light';
+    directional.position.set(5, 10, 7);
+
+    this.scene.add(ambient, directional);
+
+    this.camera.position.set(4, 4, 6);
+  }
+
+  on<K extends keyof SceneEventMap>(event: K, listener: SceneEventListener<K>): () => void {
+    this.listeners[event].push(listener as SceneEventListener<any>);
+    return () => {
+      this.listeners[event] = this.listeners[event].filter((fn) => fn !== listener);
+    };
+  }
+
+  private emit<K extends keyof SceneEventMap>(event: K, payload: SceneEventMap[K]) {
+    for (const listener of this.listeners[event]) {
+      listener(payload);
+    }
+  }
+
+  notifyChange() {
+    this.emit('change', undefined);
+  }
+
+  get selection() {
+    return this.selected;
+  }
+
+  select(object: Object3D | null) {
+    this.selected = object;
+    this.emit('selection', object);
+  }
+
+  createPrimitive(type: PrimitiveType): Object3D {
+    let geometry;
+    switch (type) {
+      case 'box':
+        geometry = new BoxGeometry(1, 1, 1);
+        break;
+      case 'sphere':
+        geometry = new SphereGeometry(0.6, 32, 24);
+        break;
+      case 'plane':
+      default:
+        geometry = new PlaneGeometry(1.5, 1.5, 1, 1);
+        geometry.rotateX(-Math.PI / 2);
+        break;
+    }
+
+    const material = new MeshStandardMaterial({ color: '#60a5fa', roughness: 0.4, metalness: 0.2 });
+    const mesh = new Mesh(geometry, material);
+    mesh.name = `${type.charAt(0).toUpperCase() + type.slice(1)} ${++objectId}`;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.position.y = type === 'plane' ? 0 : 0.5;
+
+    this.scene.add(mesh);
+    this.notifyChange();
+    return mesh;
+  }
+
+  deleteSelected() {
+    if (!this.selected) return;
+    this.selected.removeFromParent();
+    this.select(null);
+    this.notifyChange();
+  }
+
+  setMaterialProperty(property: 'color' | 'metalness' | 'roughness', value: string | number) {
+    const mesh = this.selected as Mesh | null;
+    if (!mesh || !(mesh.material instanceof MeshStandardMaterial)) return;
+    if (property === 'color' && typeof value === 'string') {
+      mesh.material.color = new Color(value);
+    } else if (property === 'metalness' && typeof value === 'number') {
+      mesh.material.metalness = value;
+    } else if (property === 'roughness' && typeof value === 'number') {
+      mesh.material.roughness = value;
+    }
+    mesh.material.needsUpdate = true;
+    this.notifyChange();
+  }
+
+  rename(object: Object3D, name: string) {
+    object.name = name;
+    this.notifyChange();
+  }
+
+  getOutlinerItems(): Object3D[] {
+    const items: Object3D[] = [];
+    this.scene.traverse((object) => {
+      if (object instanceof Mesh) {
+        items.push(object);
+      }
+    });
+    return items;
+  }
+
+  async exportScene(binary = false): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      this.exporter.parse(
+        this.scene,
+        (result) => {
+          if (result instanceof ArrayBuffer) {
+            resolve(new Blob([result], { type: 'model/gltf-binary' }));
+          } else {
+            const content = binary ? result : JSON.stringify(result, null, 2);
+            resolve(new Blob([content], { type: 'application/json' }));
+          }
+        },
+        (error) => reject(error),
+        { binary }
+      );
+    });
+  }
+
+  async serialize(): Promise<string> {
+    const blob = await this.exportScene(false);
+    return blob.text();
+  }
+
+  async saveToLocalStorage(key = '3dmodeler-scene') {
+    const serialized = await this.serialize();
+    localStorage.setItem(key, serialized);
+  }
+
+  async loadFromLocalStorage(key = '3dmodeler-scene') {
+    const stored = localStorage.getItem(key);
+    if (!stored) return;
+    await this.importFromString(stored);
+  }
+
+  async importFromFile(file: File) {
+    const buffer = await file.arrayBuffer();
+    if (file.name.toLowerCase().endsWith('.glb')) {
+      await this.importFromBinary(buffer);
+    } else {
+      await this.importFromString(new TextDecoder().decode(buffer));
+    }
+  }
+
+  async importFromBinary(buffer: ArrayBuffer) {
+    return new Promise<void>((resolve, reject) => {
+      this.loader.parse(
+        buffer,
+        '',
+        (gltf) => {
+          this.useImportedScene(gltf.scene);
+          resolve();
+        },
+        reject
+      );
+    });
+  }
+
+  async importFromString(data: string) {
+    return new Promise<void>((resolve, reject) => {
+      this.loader.parse(
+        data,
+        '',
+        (gltf) => {
+          this.useImportedScene(gltf.scene);
+          resolve();
+        },
+        reject
+      );
+    });
+  }
+
+  private useImportedScene(imported: Scene) {
+    this.clearScene();
+    imported.children.forEach((child) => {
+      child.removeFromParent();
+      this.scene.add(child);
+    });
+    this.notifyChange();
+  }
+
+  clearScene() {
+    const toRemove: Object3D[] = [];
+    this.scene.traverse((child) => {
+      if (child instanceof Mesh) {
+        toRemove.push(child);
+      }
+    });
+    toRemove.forEach((child) => child.removeFromParent());
+    this.select(null);
+    this.notifyChange();
+  }
+}

--- a/src/core/UndoStack.ts
+++ b/src/core/UndoStack.ts
@@ -1,0 +1,48 @@
+import { SceneManager } from './SceneManager';
+
+interface StateEntry {
+  data: string;
+}
+
+export class UndoStack {
+  private undoStack: StateEntry[] = [];
+  private redoStack: StateEntry[] = [];
+  private maxStates = 32;
+  private sceneManager?: SceneManager;
+
+  bind(sceneManager: SceneManager) {
+    this.sceneManager = sceneManager;
+    void this.capture();
+  }
+
+  async capture() {
+    if (!this.sceneManager) return;
+    const data = await this.sceneManager.serialize();
+    if (this.undoStack.length && this.undoStack[this.undoStack.length - 1].data === data) {
+      return;
+    }
+    this.undoStack.push({ data });
+    if (this.undoStack.length > this.maxStates) {
+      this.undoStack.shift();
+    }
+    this.redoStack.length = 0;
+  }
+
+  async undo() {
+    if (!this.sceneManager || this.undoStack.length <= 1) return;
+    const current = this.undoStack.pop();
+    if (!current) return;
+    const previous = this.undoStack[this.undoStack.length - 1];
+    if (!previous) return;
+    this.redoStack.push(current);
+    await this.sceneManager.importFromString(previous.data);
+  }
+
+  async redo() {
+    if (!this.sceneManager || this.redoStack.length === 0) return;
+    const next = this.redoStack.pop();
+    if (!next) return;
+    await this.sceneManager.importFromString(next.data);
+    this.undoStack.push(next);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,38 @@
+import './style.css';
+import { createApp } from './ui/Layout';
+import { SceneManager } from './core/SceneManager';
+import { RendererManager } from './core/RendererManager';
+import { GestureController } from './core/GestureController';
+import { GizmoManager } from './core/GizmoManager';
+import { UndoStack } from './core/UndoStack';
+
+const container = document.querySelector<HTMLDivElement>('#app');
+if (!container) {
+  throw new Error('App container not found');
+}
+
+const sceneManager = new SceneManager();
+const rendererManager = new RendererManager(sceneManager);
+const undoStack = new UndoStack();
+undoStack.bind(sceneManager);
+const gizmoManager = new GizmoManager(sceneManager, rendererManager.camera, rendererManager.domElement, undoStack);
+const gestureController = new GestureController(rendererManager, gizmoManager, sceneManager);
+gizmoManager.registerOrbitControls(gestureController.controls);
+
+const app = createApp({
+  container,
+  sceneManager,
+  rendererManager,
+  gestureController,
+  gizmoManager,
+  undoStack
+});
+app.mount();
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((error) => {
+      console.warn('Service worker registration failed', error);
+    });
+  });
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,149 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #f8fafc;
+  background: #0f172a;
+}
+
+body, html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+
+#app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    'toolbar toolbar'
+    'sidebar viewport';
+  height: 100%;
+  background: linear-gradient(180deg, #111827 0%, #020617 100%);
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto 1fr;
+    grid-template-areas:
+      'toolbar'
+      'sidebar'
+      'viewport';
+  }
+}
+
+.toolbar {
+  grid-area: toolbar;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.toolbar button, .toolbar select, .toolbar input[type="color"] {
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.85);
+  color: inherit;
+  font-size: 0.95rem;
+  touch-action: manipulation;
+}
+
+.toolbar button:active {
+  transform: scale(0.97);
+}
+
+.sidebar {
+  grid-area: sidebar;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.7);
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.viewport {
+  grid-area: viewport;
+  position: relative;
+  overflow: hidden;
+}
+
+.viewport canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.panel {
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.panel h2 {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.outliner-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.outliner-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+}
+
+.outliner-item.active {
+  background: rgba(37, 99, 235, 0.4);
+}
+
+.material-editor label,
+.material-editor input,
+.material-editor select {
+  display: block;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.file-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.file-menu button {
+  width: 100%;
+}
+
+.toast {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 118, 110, 0.8);
+  border-radius: 0.75rem;
+  color: #ecfeff;
+  transition: opacity 0.3s ease;
+}

--- a/src/ui/FileMenu.ts
+++ b/src/ui/FileMenu.ts
@@ -1,0 +1,48 @@
+import { SceneManager } from '../core/SceneManager';
+import { UndoStack } from '../core/UndoStack';
+
+interface FileMenuDeps {
+  sceneManager: SceneManager;
+  undoStack: UndoStack;
+  onToast: (message: string) => void;
+}
+
+export function createFileMenu({ sceneManager, undoStack, onToast }: FileMenuDeps) {
+  const panel = document.createElement('div');
+  panel.className = 'panel file-menu';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Files';
+  panel.appendChild(title);
+
+  const newButton = document.createElement('button');
+  newButton.textContent = 'New Scene';
+  newButton.addEventListener('click', async () => {
+    sceneManager.clearScene();
+    await undoStack.capture();
+    onToast('Scene cleared');
+  });
+  panel.appendChild(newButton);
+
+  const sampleButton = document.createElement('button');
+  sampleButton.textContent = 'Load Sample';
+  sampleButton.addEventListener('click', async () => {
+    const response = await fetch('/sample.gltf');
+    const text = await response.text();
+    await sceneManager.importFromString(text);
+    await undoStack.capture();
+    onToast('Sample scene loaded');
+  });
+  panel.appendChild(sampleButton);
+
+  const deleteButton = document.createElement('button');
+  deleteButton.textContent = 'Delete Selection';
+  deleteButton.addEventListener('click', async () => {
+    sceneManager.deleteSelected();
+    await undoStack.capture();
+    onToast('Selection removed');
+  });
+  panel.appendChild(deleteButton);
+
+  return { element: panel };
+}

--- a/src/ui/Layout.ts
+++ b/src/ui/Layout.ts
@@ -1,0 +1,84 @@
+import { SceneManager } from '../core/SceneManager';
+import { RendererManager } from '../core/RendererManager';
+import { GestureController } from '../core/GestureController';
+import { GizmoManager } from '../core/GizmoManager';
+import { UndoStack } from '../core/UndoStack';
+import { createToolbar } from './Toolbar';
+import { createOutliner } from './Outliner';
+import { createMaterialEditor } from './MaterialEditorPanel';
+import { createFileMenu } from './FileMenu';
+
+interface AppOptions {
+  container: HTMLElement;
+  sceneManager: SceneManager;
+  rendererManager: RendererManager;
+  gestureController: GestureController;
+  gizmoManager: GizmoManager;
+  undoStack: UndoStack;
+}
+
+export function createApp(options: AppOptions) {
+  const { container, sceneManager, rendererManager, gestureController, gizmoManager, undoStack } = options;
+
+  const shell = document.createElement('div');
+  shell.className = 'app-shell';
+
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.style.opacity = '0';
+  let toastTimer: number | undefined;
+
+  const showToast = (message: string) => {
+    toast.textContent = message;
+    toast.style.opacity = '1';
+    if (toastTimer) {
+      window.clearTimeout(toastTimer);
+    }
+    toastTimer = window.setTimeout(() => {
+      toast.style.opacity = '0';
+    }, 2500);
+  };
+
+  const toolbar = createToolbar({
+    sceneManager,
+    gizmoManager,
+    undoStack,
+    gestureController,
+    onToast: showToast
+  }).element;
+
+  const sidebar = document.createElement('aside');
+  sidebar.className = 'sidebar';
+
+  const outliner = createOutliner({ sceneManager, gizmoManager }).element;
+  const materialEditor = createMaterialEditor(sceneManager, undoStack).element;
+  const fileMenu = createFileMenu({ sceneManager, undoStack, onToast: showToast }).element;
+
+  sidebar.append(fileMenu, outliner, materialEditor);
+
+  const viewport = document.createElement('div');
+  viewport.className = 'viewport';
+
+  shell.append(toolbar, sidebar, viewport, toast);
+
+  let disposeSelection: (() => void) | undefined;
+
+  const mount = () => {
+    container.appendChild(shell);
+    rendererManager.mount(viewport);
+    disposeSelection = sceneManager.on('selection', (selection) => {
+      if (!selection) {
+        gizmoManager.detach();
+      }
+    });
+    void sceneManager.loadFromLocalStorage().then(() => undoStack.capture());
+  };
+
+  const unmount = () => {
+    rendererManager.unmount();
+    shell.remove();
+    disposeSelection?.();
+  };
+
+  return { mount, unmount };
+}

--- a/src/ui/MaterialEditorPanel.ts
+++ b/src/ui/MaterialEditorPanel.ts
@@ -1,0 +1,73 @@
+import { Mesh, MeshStandardMaterial } from 'three';
+import { SceneManager } from '../core/SceneManager';
+import { UndoStack } from '../core/UndoStack';
+
+export function createMaterialEditor(sceneManager: SceneManager, undoStack: UndoStack) {
+  const panel = document.createElement('div');
+  panel.className = 'panel material-editor';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Material';
+  panel.appendChild(title);
+
+  const colorLabel = document.createElement('label');
+  colorLabel.textContent = 'Color';
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.value = '#60a5fa';
+  const handleCapture = () => void undoStack.capture();
+
+  colorInput.addEventListener('input', () => {
+    sceneManager.setMaterialProperty('color', colorInput.value);
+  });
+  colorInput.addEventListener('change', handleCapture);
+  colorLabel.appendChild(colorInput);
+  panel.appendChild(colorLabel);
+
+  const metalnessLabel = document.createElement('label');
+  metalnessLabel.textContent = 'Metalness';
+  const metalnessRange = document.createElement('input');
+  metalnessRange.type = 'range';
+  metalnessRange.min = '0';
+  metalnessRange.max = '1';
+  metalnessRange.step = '0.01';
+  metalnessRange.addEventListener('input', () => {
+    sceneManager.setMaterialProperty('metalness', parseFloat(metalnessRange.value));
+  });
+  metalnessRange.addEventListener('change', handleCapture);
+  metalnessLabel.appendChild(metalnessRange);
+  panel.appendChild(metalnessLabel);
+
+  const roughnessLabel = document.createElement('label');
+  roughnessLabel.textContent = 'Roughness';
+  const roughnessRange = document.createElement('input');
+  roughnessRange.type = 'range';
+  roughnessRange.min = '0';
+  roughnessRange.max = '1';
+  roughnessRange.step = '0.01';
+  roughnessRange.addEventListener('input', () => {
+    sceneManager.setMaterialProperty('roughness', parseFloat(roughnessRange.value));
+  });
+  roughnessRange.addEventListener('change', handleCapture);
+  roughnessLabel.appendChild(roughnessRange);
+  panel.appendChild(roughnessLabel);
+
+  const update = () => {
+    const mesh = sceneManager.selection as Mesh | null;
+    const material = mesh?.material instanceof MeshStandardMaterial ? mesh.material : null;
+    const enabled = Boolean(material);
+    [colorInput, metalnessRange, roughnessRange].forEach((input) => {
+      input.disabled = !enabled;
+    });
+    if (!material) return;
+    colorInput.value = `#${material.color.getHexString()}`;
+    metalnessRange.value = material.metalness.toFixed(2);
+    roughnessRange.value = material.roughness.toFixed(2);
+  };
+
+  sceneManager.on('selection', update);
+  sceneManager.on('change', update);
+  update();
+
+  return { element: panel };
+}

--- a/src/ui/Outliner.ts
+++ b/src/ui/Outliner.ts
@@ -1,0 +1,51 @@
+import { Object3D } from 'three';
+import { SceneManager } from '../core/SceneManager';
+import { GizmoManager } from '../core/GizmoManager';
+
+interface OutlinerDeps {
+  sceneManager: SceneManager;
+  gizmoManager: GizmoManager;
+}
+
+export function createOutliner({ sceneManager, gizmoManager }: OutlinerDeps) {
+  const panel = document.createElement('div');
+  panel.className = 'panel';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Outliner';
+  panel.appendChild(title);
+
+  const list = document.createElement('ul');
+  list.className = 'outliner-list';
+  panel.appendChild(list);
+
+  const render = () => {
+    list.innerHTML = '';
+    const items = sceneManager.getOutlinerItems();
+    items.forEach((object) => {
+      const item = document.createElement('li');
+      item.className = 'outliner-item';
+      item.textContent = object.name || object.type;
+      if (sceneManager.selection === object) {
+        item.classList.add('active');
+      }
+      item.addEventListener('click', () => {
+        sceneManager.select(object);
+        gizmoManager.attach(object);
+      });
+      item.addEventListener('dblclick', () => {
+        const next = prompt('Rename object', object.name);
+        if (next) {
+          sceneManager.rename(object, next);
+        }
+      });
+      list.appendChild(item);
+    });
+  };
+
+  sceneManager.on('change', render);
+  sceneManager.on('selection', render);
+  render();
+
+  return { element: panel };
+}

--- a/src/ui/Toolbar.ts
+++ b/src/ui/Toolbar.ts
@@ -1,0 +1,136 @@
+import { SceneManager, PrimitiveType } from '../core/SceneManager';
+import { GizmoManager, TransformMode } from '../core/GizmoManager';
+import { UndoStack } from '../core/UndoStack';
+import { GestureController } from '../core/GestureController';
+
+interface ToolbarDeps {
+  sceneManager: SceneManager;
+  gizmoManager: GizmoManager;
+  undoStack: UndoStack;
+  gestureController: GestureController;
+  onToast: (message: string) => void;
+}
+
+export function createToolbar(deps: ToolbarDeps) {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'toolbar';
+
+  const makeButton = (label: string, onClick: () => void, capture = true) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', async () => {
+      onClick();
+      if (capture) {
+        await deps.undoStack.capture();
+      }
+    });
+    return button;
+  };
+
+  const primitiveButtons: { type: PrimitiveType; label: string }[] = [
+    { type: 'box', label: 'Cube' },
+    { type: 'sphere', label: 'Sphere' },
+    { type: 'plane', label: 'Plane' }
+  ];
+
+  const primitiveGroup = document.createElement('div');
+  primitiveButtons.forEach(({ type, label }) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', async () => {
+      const mesh = deps.sceneManager.createPrimitive(type);
+      deps.sceneManager.select(mesh);
+      deps.gizmoManager.attach(mesh);
+      deps.gestureController.focusOn(mesh);
+      await deps.undoStack.capture();
+    });
+    primitiveGroup.appendChild(button);
+  });
+  toolbar.appendChild(primitiveGroup);
+
+  const modeSelect = document.createElement('select');
+  const modes: { value: TransformMode; label: string }[] = [
+    { value: 'translate', label: 'Move' },
+    { value: 'rotate', label: 'Rotate' },
+    { value: 'scale', label: 'Scale' }
+  ];
+  modes.forEach((mode) => {
+    const option = document.createElement('option');
+    option.value = mode.value;
+    option.textContent = mode.label;
+    modeSelect.appendChild(option);
+  });
+  modeSelect.addEventListener('change', () => {
+    deps.gizmoManager.setMode(modeSelect.value as TransformMode);
+  });
+  toolbar.appendChild(modeSelect);
+
+  const undoButton = makeButton('Undo', () => {
+    void deps.undoStack.undo();
+  }, false);
+  const redoButton = makeButton('Redo', () => {
+    void deps.undoStack.redo();
+  }, false);
+  toolbar.append(undoButton, redoButton);
+
+  const focusButton = document.createElement('button');
+  focusButton.textContent = 'Focus';
+  focusButton.addEventListener('click', () => {
+    deps.gestureController.focusOn(deps.sceneManager.selection);
+  });
+  toolbar.appendChild(focusButton);
+
+  const resetCameraButton = document.createElement('button');
+  resetCameraButton.textContent = 'Reset Camera';
+  resetCameraButton.addEventListener('click', () => deps.gestureController.resetCamera());
+  toolbar.appendChild(resetCameraButton);
+
+  const saveButton = document.createElement('button');
+  saveButton.textContent = 'Save';
+  saveButton.addEventListener('click', async () => {
+    await deps.sceneManager.saveToLocalStorage();
+    deps.onToast('Scene saved to local storage');
+  });
+  toolbar.appendChild(saveButton);
+
+  const loadButton = document.createElement('button');
+  loadButton.textContent = 'Load';
+  loadButton.addEventListener('click', async () => {
+    await deps.sceneManager.loadFromLocalStorage();
+    deps.onToast('Scene loaded');
+  });
+  toolbar.appendChild(loadButton);
+
+  const exportButton = document.createElement('button');
+  exportButton.textContent = 'Export GLB';
+  exportButton.addEventListener('click', async () => {
+    const blob = await deps.sceneManager.exportScene(true);
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'scene.glb';
+    anchor.click();
+    URL.revokeObjectURL(url);
+    deps.onToast('Exported GLB');
+  });
+  toolbar.appendChild(exportButton);
+
+  const importLabel = document.createElement('label');
+  importLabel.textContent = 'Import';
+  const importInput = document.createElement('input');
+  importInput.type = 'file';
+  importInput.accept = '.gltf,.glb';
+  importInput.addEventListener('change', async () => {
+    if (!importInput.files?.length) return;
+    await deps.sceneManager.importFromFile(importInput.files[0]);
+    deps.onToast('File imported');
+    await deps.undoStack.capture();
+    importInput.value = '';
+  });
+  importLabel.appendChild(importInput);
+  toolbar.appendChild(importLabel);
+
+  return { element: toolbar };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowJs": false,
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    host: true
+  },
+  build: {
+    target: "es2020"
+  }
+});


### PR DESCRIPTION
## Summary
- replace the binary PNG application icons with vector SVG alternatives to keep the repository text-only
- update the HTML and manifest references so the PWA uses the new SVG icons

## Testing
- not run (node dependencies unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2661de9988327b65d6aad3fe7c366