### PR TITLE
Handle BASE_URL for service worker and sample assets

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,18 @@
 const CACHE_NAME = '3dmodeler-cache-v1';
+
+const scopeUrl = self.registration?.scope ? new URL(self.registration.scope) : new URL(self.location.href);
+const basePath = scopeUrl.pathname.endsWith('/') ? scopeUrl.pathname : `${scopeUrl.pathname}/`;
+const toBasePath = (path = '') => {
+  const normalized = path.startsWith('/') ? path.slice(1) : path;
+  return `${basePath}${normalized}`;
+};
+
 const OFFLINE_URLS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest'
+  basePath,
+  toBasePath('index.html'),
+  toBasePath('manifest.webmanifest')
 ];
+const FALLBACK_DOCUMENT = toBasePath('index.html');
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
@@ -24,7 +33,7 @@ self.addEventListener('fetch', (event) => {
         const copy = response.clone();
         caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
         return response;
-      }).catch(() => caches.match('/index.html'))
+      }).catch(() => caches.match(FALLBACK_DOCUMENT))
     )
   );
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,10 @@ app.mount();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
+    const base = import.meta.env.BASE_URL ?? '/';
+    const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+    const swPath = `${normalizedBase}sw.js`.replace(/\/{2,}/g, '/');
+    navigator.serviceWorker.register(swPath).catch((error) => {
       console.warn('Service worker registration failed', error);
     });
   });

--- a/src/ui/FileMenu.ts
+++ b/src/ui/FileMenu.ts
@@ -27,7 +27,10 @@ export function createFileMenu({ sceneManager, undoStack, onToast }: FileMenuDep
   const sampleButton = document.createElement('button');
   sampleButton.textContent = 'Load Sample';
   sampleButton.addEventListener('click', async () => {
-    const response = await fetch('/sample.gltf');
+    const base = import.meta.env.BASE_URL ?? '/';
+    const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+    const sampleUrl = `${normalizedBase}sample.gltf`.replace(/\/{2,}/g, '/');
+    const response = await fetch(sampleUrl);
     const text = await response.text();
     await sceneManager.importFromString(text);
     await undoStack.capture();


### PR DESCRIPTION
## Summary
- register the service worker using the configured Vite base path
- load the sample glTF using the deployment base so nested paths work
- derive cached asset URLs in the service worker from its scope instead of hard-coded root paths

## Testing
- npm run build *(fails: package.json is invalid JSON in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2763b938c83279164c506162d9dc3