### PR TITLE
Fix malformed package.json manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,4 @@
 {
-codex/create-ci-workflow-and-deployment-instructions
-  "name": "3dmodel",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Automation scaffolding for the 3dmodel project.",
-  "scripts": {
-    "build": "node scripts/build.js",
-    "deploy": "npm run build && npx gh-pages -d dist --dotfiles"
-  },
-  "devDependencies": {
-    "gh-pages": "^6.0.0"
-
   "name": "3dmodeler",
   "version": "0.1.0",
   "private": true,
@@ -26,6 +14,5 @@ codex/create-ci-workflow-and-deployment-instructions
   "devDependencies": {
     "typescript": "^5.4.2",
     "vite": "^5.1.0"
-main
   }
 }


### PR DESCRIPTION
## Summary
- remove the stray workflow line and duplicate scaffolding to restore a valid package.json
- keep the intended Vite/Three.js metadata in a single manifest object

## Testing
- npm install *(fails: 403 Forbidden when fetching three)*

------
https://chatgpt.com/codex/tasks/task_e_68e2762e373c832794faa7c15494c8db