### PR TITLE
Preserve persistent helpers when clearing scene

### DIFF
--- a/src/core/GizmoManager.ts
+++ b/src/core/GizmoManager.ts
@@ -34,6 +34,7 @@ export class GizmoManager {
       void this.undoStack.capture();
     });
     this.sceneManager.scene.add(this.controls);
+    this.sceneManager.markPersistent(this.controls);
   }
 
   registerOrbitControls(controls: OrbitControls) {


### PR DESCRIPTION
## Summary
- add persistent object tracking to the scene manager so helper nodes survive scene clears
- expose markPersistent and use it for default lights and transform controls
- exclude persistent helpers when building outliner listings and during scene resets

## Testing
- npm run build *(fails: missing access to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e2796dee108327b97e32755e98d6a2