### PR TITLE
Configure TypeScript node typings for bundler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "three": "^0.162.0"
   },
   "devDependencies": {
+    "@types/node": "^20.11.30",
     "typescript": "^5.4.2",
     "vite": "^5.1.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,14 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowJs": false,
     "strict": true,
     "noEmit": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
     "composite": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add @types/node to the devDependencies
- update the main and node TypeScript configs to use bundler-aware resolution and include Node typings

## Testing
- npm run build *(fails: missing @types/node package due to restricted npm registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68e284353858832786283b7386ffe420