### PR TITLE
Include WebWorker libs in TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,24 @@
     "noEmit": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "node"]
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable",
+      "WebWorker",
+      "WebWorker.ImportScripts"
+    ],
+    "types": [
+      "vite/client",
+      "node"
+    ]
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- include the WebWorker and WebWorker.ImportScripts libraries in the TypeScript configuration so worker typings resolve correctly

## Testing
- npm run build *(fails: missing @types/node and vite/client typings due to restricted access to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e286b4711c8327ba73b600753905c3