### PR TITLE
Add Three.js type definitions to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "@types/three": "^0.162.0",
     "typescript": "^5.4.2",
     "vite": "^5.1.0"
   }


### PR DESCRIPTION
## Summary
- add @types/three to the devDependencies list so Three.js types are available to the project

## Testing
- npm install *(fails: 403 Forbidden when fetching @types/node from registry)*
- npm run build *(fails: missing type definition files because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e286b65c4083279ca1537c372b8e15