### PR TITLE
Remove web worker libraries from project tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
       "ES2020",
       "DOM",
       "DOM.Iterable",
-      "WebWorker",
-      "WebWorker.ImportScripts"
+      "DOM.AsyncIterable"
     ],
     "types": [
       "vite/client",


### PR DESCRIPTION
## Summary
- remove the WebWorker libraries from the main tsconfig so only DOM targets remain
- include DOM.AsyncIterable to preserve async iterator support without worker globals

## Testing
- npm run build *(fails: missing @types/node and @types/vite definitions because packages cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e289217d18832787139a435ce6522d