### PR TITLE
Fix TransformControls dragging event typing

### DIFF
--- a/src/core/GizmoManager.ts
+++ b/src/core/GizmoManager.ts
@@ -1,5 +1,6 @@
 import { Object3D, PerspectiveCamera } from 'three';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import type { TransformControlsEvent } from 'three/examples/jsm/controls/TransformControls.js';
 import { SceneManager } from './SceneManager';
 import { UndoStack } from './UndoStack';
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -20,7 +21,7 @@ export class GizmoManager {
   ) {
     this.controls = new TransformControls(camera, domElement);
     this.controls.setSize(1.1);
-    this.controls.addEventListener('dragging-changed', (event) => {
+    this.controls.addEventListener('dragging-changed', (event: TransformControlsEvent) => {
       this.active = event.value;
       if (this.orbitControls) {
         this.orbitControls.enabled = !event.value;


### PR DESCRIPTION
## Summary
- import the `TransformControlsEvent` type so the dragging callback narrows the value flag
- type the `'dragging-changed'` handler to keep the orbit control toggle strongly typed

## Testing
- npm run build *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68e2892427888327aa818547a47c1034