### PR TITLE
Adjust GLTF export MIME types

### DIFF
--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -165,11 +165,12 @@ export class SceneManager {
       this.exporter.parse(
         this.scene,
         (result) => {
+          const mimeType = binary ? 'model/gltf-binary' : 'application/json';
           if (result instanceof ArrayBuffer) {
-            resolve(new Blob([result], { type: 'model/gltf-binary' }));
+            resolve(new Blob([result], { type: mimeType }));
           } else {
-            const content = binary ? result : JSON.stringify(result, null, 2);
-            resolve(new Blob([content], { type: 'application/json' }));
+            const content = JSON.stringify(result, null, 2);
+            resolve(new Blob([content], { type: mimeType }));
           }
         },
         (error) => reject(error),


### PR DESCRIPTION
## Summary
- update the scene exporter to always stringify JSON exports before creating the Blob
- align GLTF export MIME types with the selected export mode

## Testing
- npm run build *(fails: TS2688 cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68e28924f69c8327a80f3025632be8b0