### PR TITLE
Allow importing Group scenes

### DIFF
--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -3,6 +3,7 @@ import {
   BoxGeometry,
   Color,
   DirectionalLight,
+  Group,
   Mesh,
   MeshStandardMaterial,
   Object3D,
@@ -231,9 +232,10 @@ export class SceneManager {
     });
   }
 
-  private useImportedScene(imported: Scene) {
+  private useImportedScene(imported: Scene | Group) {
     this.clearScene();
-    imported.children.forEach((child) => {
+    const children = [...imported.children];
+    children.forEach((child) => {
       child.removeFromParent();
       this.scene.add(child);
     });


### PR DESCRIPTION
## Summary
- allow `SceneManager.useImportedScene` to accept either a `Scene` or `Group` when importing GLTF content
- clone the imported children list before reparenting so both scenes and groups are handled safely

## Testing
- npm run build *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68e289263c1883279ae9847d93f2d76a