### PR TITLE
Fix TransformControls dragging event typing

### DIFF
--- a/src/core/GizmoManager.ts
+++ b/src/core/GizmoManager.ts
@@ -1,6 +1,6 @@
 import { Object3D, PerspectiveCamera } from 'three';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
-import type { TransformControlsEvent } from 'three/examples/jsm/controls/TransformControls.js';
+import type { TransformControlsEventMap } from 'three/examples/jsm/controls/TransformControls.js';
 import { SceneManager } from './SceneManager';
 import { UndoStack } from './UndoStack';
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -21,16 +21,19 @@ export class GizmoManager {
   ) {
     this.controls = new TransformControls(camera, domElement);
     this.controls.setSize(1.1);
-    this.controls.addEventListener('dragging-changed', (event: TransformControlsEvent) => {
-      this.active = event.value;
-      if (this.orbitControls) {
-        this.orbitControls.enabled = !event.value;
+    this.controls.addEventListener(
+      'dragging-changed',
+      (event: TransformControlsEventMap['dragging-changed']) => {
+        this.active = event.value;
+        if (this.orbitControls) {
+          this.orbitControls.enabled = !event.value;
+        }
+        if (!event.value) {
+          void this.undoStack.capture();
+          this.sceneManager.notifyChange();
+        }
       }
-      if (!event.value) {
-        void this.undoStack.capture();
-        this.sceneManager.notifyChange();
-      }
-    });
+    );
     this.controls.addEventListener('mouseDown', () => {
       void this.undoStack.capture();
     });


### PR DESCRIPTION
## Summary
- replace the nonexistent TransformControlsEvent type import with TransformControlsEventMap
- use the correct event map entry for the dragging-changed listener so event.value is typed as a boolean

## Testing
- npm run build *(fails: pre-existing missing type definitions for three and Worker)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ce1c6c4832795ade87d4b8be34f