### PR TITLE
Add ambient worker declarations for Vite types

### DIFF
--- a/types/dom/workers.d.ts
+++ b/types/dom/workers.d.ts
@@ -1,0 +1,11 @@
+interface Worker {}
+interface SharedWorker {}
+
+declare var Worker: {
+  new (...args: any[]): Worker;
+};
+
+declare var SharedWorker: {
+  new (...args: any[]): SharedWorker;
+};
+export {};


### PR DESCRIPTION
## Summary
- add custom ambient Worker and SharedWorker declarations under the existing type roots
- expose minimal constructor signatures so Vite's worker typings can resolve

## Testing
- npm run build *(fails: existing TS2724 error in src/core/GizmoManager.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d701b3688327bc497394994a046c