### PR TITLE
Enable marquee drag selection for mesh handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ The project is designed for static hosting, such as GitHub Pages or Netlify. Run
 ### Automation & Workflows
 At present there are no CI/CD pipelines or deployment workflows defined in this repository. If you adopt GitHub Pages, consider adding a GitHub Actions workflow (for example, `.github/workflows/deploy.yml`) that runs `npm install`, `npm run build`, and publishes the `dist/` folder automatically.
 
+## Manual Testing
+
+### Drag Selection Workflow
+1. Select a mesh and switch the edit mode to **Vertex**. Drag with the primary pointer to draw the marquee and confirm that every vertex inside the rectangle is highlighted and that the gizmo snaps to the averaged pivot. Repeat the test while holding **Shift** (add) and **Ctrl/Cmd** (toggle removal).
+2. Switch to **Edge** mode and marquee-select across multiple edges. Verify that moving the transform gizmo translates the entire edge selection and that releasing the drag keeps the pivot centered on the group.
+3. Switch to **Face** mode, marquee-select several faces, and translate them as a group. Confirm that a marquee that captures no handles falls back to single-click behavior so a lone face can still be selected.
+4. For each mode, drag-select while holding **Ctrl/Cmd** to remove handles from an existing selection and ensure the gizmo updates or detaches when no handles remain.
+
 ## Roadmap
 - [ ] Add automated GitHub Actions build-and-deploy pipeline.
 - [ ] Provide drag-and-drop asset upload directly in the UI.

--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -36,6 +36,20 @@ const tempVectorD = new Vector3();
 const tempVectorE = new Vector3();
 const tempVectorF = new Vector3();
 const tempQuaternion = new Quaternion();
+const tempVectorG = new Vector3();
+const tempVectorH = new Vector3();
+
+interface NormalizedSelectionRect {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+interface SelectionOptions {
+  additive?: boolean;
+  toggle?: boolean;
+}
 
 export class EditableMeshController {
   private handlesGroup = new Group();
@@ -44,6 +58,10 @@ export class EditableMeshController {
   private activeMesh: Mesh | null = null;
   private handles: HandleDescriptor[] = [];
   private activeHandle?: HandleDescriptor;
+  private selectedHandles = new Set<HandleDescriptor>();
+  private selectionPivot = new Object3D();
+  private transformTarget?: Object3D;
+  private transformReference = new Vector3();
   private dragging = false;
   private vertexGeometry = new SphereGeometry(0.04, 12, 12);
   private edgeGeometry = new BoxGeometry(0.08, 0.08, 0.08);
@@ -83,17 +101,19 @@ export class EditableMeshController {
       if (this.orbitControls) {
         this.orbitControls.enabled = !event.value;
       }
-      if (!event.value) {
-        if (this.activeHandle) {
-          this.commitHandleEdit(this.activeHandle);
-          this.sceneManager.notifyChange();
-          void this.undoStack.capture();
+      if (event.value) {
+        if (this.transformTarget) {
+          this.transformReference.copy(this.transformTarget.position);
         }
+      } else if (this.selectedHandles.size > 0 || this.activeHandle) {
+        this.commitSelectionEdit();
+        this.sceneManager.notifyChange();
+        void this.undoStack.capture();
       }
     });
     this.handleControls.addEventListener('objectChange', () => {
-      if (!this.activeHandle || !this.dragging) return;
-      this.applyHandleDelta(this.activeHandle);
+      if (!this.dragging || !this.transformTarget) return;
+      this.applySelectionDelta();
       this.sceneManager.notifyChange();
     });
 
@@ -103,6 +123,11 @@ export class EditableMeshController {
     this.handlesGroup.visible = false;
     this.sceneManager.scene.add(this.handlesGroup);
     this.sceneManager.markPersistent(this.handlesGroup);
+
+    this.selectionPivot.name = 'Selection Pivot';
+    this.selectionPivot.visible = false;
+    this.sceneManager.scene.add(this.selectionPivot);
+    this.sceneManager.markPersistent(this.selectionPivot);
 
     this.sceneManager.on('selection', () => this.onSelectionChanged());
     this.sceneManager.on('change', () => this.refreshHandles());
@@ -135,6 +160,9 @@ export class EditableMeshController {
     this.activeMesh = null;
     this.handles = [];
     this.activeHandle = undefined;
+    this.selectedHandles.clear();
+    this.transformTarget = undefined;
+    this.selectionPivot.visible = false;
     this.handlesGroup.clear();
     this.handlesGroup.visible = false;
     this.handleControls.visible = false;
@@ -183,6 +211,9 @@ export class EditableMeshController {
     this.handlesGroup.clear();
     this.handles = [];
     this.activeHandle = undefined;
+    this.selectedHandles.clear();
+    this.transformTarget = undefined;
+    this.selectionPivot.visible = false;
     this.handleControls.detach();
     this.handleControls.visible = false;
 
@@ -266,12 +297,7 @@ export class EditableMeshController {
       handle.object.visible = visibleKinds.has(handle.kind);
     });
 
-    const shouldShowControls = this.activeHandle && visibleKinds.has(this.activeHandle.kind);
-    if (!shouldShowControls) {
-      this.handleControls.visible = false;
-      this.handleControls.detach();
-      this.activeHandle = undefined;
-    }
+    this.updateSelectionState();
   }
 
   private getVertexPosition(attr: BufferAttribute, index: number, target = new Vector3()) {
@@ -339,15 +365,27 @@ export class EditableMeshController {
         }
       }
     }
+    this.updateHandleHighlights();
+    if (!this.dragging) {
+      this.updateTransformAttachment();
+    }
   }
 
-  private applyHandleDelta(handle: HandleDescriptor) {
-    if (!this.activeMesh) return;
-    const delta = tempVector.copy(handle.object.position).sub(handle.referencePosition);
+  private applySelectionDelta() {
+    if (!this.activeMesh || !this.transformTarget) return;
+    const delta = tempVector.copy(this.transformTarget.position).sub(this.transformReference);
     if (delta.lengthSq() === 0) return;
     const geometry = this.activeMesh.geometry as BufferGeometry;
     const positionAttr = geometry.getAttribute('position') as BufferAttribute;
-    for (const index of handle.indices) {
+    const handles = this.getHandlesForTransformation();
+    if (handles.length === 0) return;
+    const indices = new Set<number>();
+    for (const handle of handles) {
+      for (const index of handle.indices) {
+        indices.add(index);
+      }
+    }
+    for (const index of indices) {
       const x = positionAttr.getX(index) + delta.x;
       const y = positionAttr.getY(index) + delta.y;
       const z = positionAttr.getZ(index) + delta.z;
@@ -355,55 +393,178 @@ export class EditableMeshController {
     }
     positionAttr.needsUpdate = true;
     geometry.computeVertexNormals();
-    handle.referencePosition.add(delta);
-    this.updateRelatedHandles(handle);
-  }
-
-  private commitHandleEdit(handle: HandleDescriptor) {
     this.refreshHandles();
-    this.handleControls.visible = true;
-    this.handleControls.attach(handle.object);
+    this.transformReference.copy(this.transformTarget.position);
   }
 
-  private updateRelatedHandles(active: HandleDescriptor) {
-    if (!this.activeMesh) return;
-    const geometry = this.activeMesh.geometry as BufferGeometry;
-    const positionAttr = geometry.getAttribute('position') as BufferAttribute;
-    for (const handle of this.handles) {
-      if (handle === active) continue;
-      switch (handle.kind) {
-        case 'vertex': {
-          const index = handle.indices[0];
-          this.getVertexPosition(positionAttr, index, tempVector);
-          handle.object.position.copy(tempVector);
-          handle.referencePosition.copy(tempVector);
-          break;
-        }
-        case 'edge': {
-          const [a, b] = handle.indices;
-          const center = this.computeEdgeCenter(positionAttr, a, b);
-          handle.object.position.copy(center);
-          handle.referencePosition.copy(center);
-          break;
-        }
-        case 'face': {
-          const [a, b, c] = handle.indices;
-          const center = this.computeFaceCenter(positionAttr, a, b, c);
-          handle.object.position.copy(center);
-          handle.referencePosition.copy(center);
-          const normal = this.computeFaceNormal(positionAttr, a, b, c);
-          tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), normal);
-          handle.object.quaternion.copy(tempQuaternion);
-          break;
-        }
+  private commitSelectionEdit() {
+    this.refreshHandles();
+    this.updateSelectionState();
+  }
+
+  private getHandlesForTransformation(): HandleDescriptor[] {
+    const handles = this.getVisibleSelectionHandles();
+    if (handles.length === 0 && this.activeHandle && this.activeHandle.object.visible) {
+      handles.push(this.activeHandle);
+    }
+    return handles;
+  }
+
+  private updateSelectionState() {
+    this.filterSelectionByVisibility();
+    if (this.selectedHandles.size === 0) {
+      this.clearSelection();
+      return;
+    }
+    if (this.activeHandle && !this.selectedHandles.has(this.activeHandle)) {
+      this.activeHandle = this.selectedHandles.values().next().value;
+    }
+    if (!this.activeHandle) {
+      this.activeHandle = this.selectedHandles.values().next().value;
+    }
+    this.updateHandleHighlights();
+    if (!this.dragging) {
+      this.updateTransformAttachment();
+    }
+  }
+
+  private filterSelectionByVisibility() {
+    let removed = false;
+    for (const handle of Array.from(this.selectedHandles)) {
+      if (!handle.object.visible) {
+        this.selectedHandles.delete(handle);
+        removed = true;
       }
     }
+    if (removed && this.activeHandle && !this.selectedHandles.has(this.activeHandle)) {
+      this.activeHandle = undefined;
+    }
   }
 
-  private clearHandleHighlights() {
-    for (const handle of this.handles) {
-      this.highlightHandle(handle, false);
+  private getVisibleSelectionHandles(): HandleDescriptor[] {
+    const handles: HandleDescriptor[] = [];
+    for (const handle of Array.from(this.selectedHandles)) {
+      if (handle.object.visible) {
+        handles.push(handle);
+      } else {
+        this.selectedHandles.delete(handle);
+      }
     }
+    return handles;
+  }
+
+  private updateTransformAttachment() {
+    const handles = this.getVisibleSelectionHandles();
+    if (handles.length === 0) {
+      this.transformTarget = undefined;
+      this.handleControls.visible = false;
+      this.handleControls.detach();
+      this.selectionPivot.visible = false;
+      return;
+    }
+    if (handles.length === 1) {
+      const handle = handles[0];
+      this.selectionPivot.visible = false;
+      if (this.transformTarget !== handle.object) {
+        this.handleControls.attach(handle.object);
+      }
+      this.handleControls.visible = true;
+      this.transformTarget = handle.object;
+      this.transformReference.copy(handle.referencePosition);
+      this.activeHandle = handle;
+    } else {
+      this.updateSelectionPivot(handles);
+      if (this.transformTarget !== this.selectionPivot) {
+        this.handleControls.attach(this.selectionPivot);
+      }
+      this.handleControls.visible = true;
+      this.transformTarget = this.selectionPivot;
+      this.transformReference.copy(this.selectionPivot.position);
+    }
+  }
+
+  private updateSelectionPivot(handles: HandleDescriptor[]) {
+    tempVectorH.set(0, 0, 0);
+    for (const handle of handles) {
+      handle.object.getWorldPosition(tempVectorG);
+      tempVectorH.add(tempVectorG);
+    }
+    tempVectorH.multiplyScalar(1 / handles.length);
+    this.selectionPivot.position.copy(tempVectorH);
+    this.selectionPivot.quaternion.set(0, 0, 0, 1);
+  }
+
+  private updateHandleHighlights() {
+    for (const handle of this.handles) {
+      this.highlightHandle(handle, this.selectedHandles.has(handle));
+    }
+  }
+
+  private clearSelection() {
+    this.selectedHandles.clear();
+    this.activeHandle = undefined;
+    this.transformTarget = undefined;
+    this.handleControls.visible = false;
+    this.handleControls.detach();
+    this.selectionPivot.visible = false;
+    this.updateHandleHighlights();
+  }
+
+  private selectHandles(handles: HandleDescriptor[], options: SelectionOptions = {}) {
+    const toggle = options.toggle ?? false;
+    const additive = options.additive ?? false;
+    if (!additive && !toggle) {
+      this.selectedHandles.clear();
+    }
+    let lastAdded: HandleDescriptor | undefined;
+    if (toggle) {
+      for (const handle of handles) {
+        if (this.selectedHandles.has(handle)) {
+          this.selectedHandles.delete(handle);
+        } else if (handle.object.visible) {
+          this.selectedHandles.add(handle);
+          lastAdded = handle;
+        }
+      }
+    } else {
+      for (const handle of handles) {
+        if (!handle.object.visible) continue;
+        this.selectedHandles.add(handle);
+        lastAdded = handle;
+      }
+    }
+    if (lastAdded) {
+      this.activeHandle = lastAdded;
+    } else if (this.activeHandle && !this.selectedHandles.has(this.activeHandle)) {
+      this.activeHandle = this.selectedHandles.values().next().value;
+    } else if (!this.activeHandle && this.selectedHandles.size > 0) {
+      this.activeHandle = this.selectedHandles.values().next().value;
+    }
+    this.updateSelectionState();
+  }
+
+  selectHandlesInRect(bounds: NormalizedSelectionRect, options: SelectionOptions = {}) {
+    const handlesInRect: HandleDescriptor[] = [];
+    const camera = this.rendererManager.camera;
+    for (const handle of this.handles) {
+      if (!handle.object.visible) continue;
+      handle.object.getWorldPosition(tempVectorG);
+      tempVectorG.project(camera);
+      if (tempVectorG.z < -1 || tempVectorG.z > 1) continue;
+      if (
+        tempVectorG.x >= bounds.minX &&
+        tempVectorG.x <= bounds.maxX &&
+        tempVectorG.y >= bounds.minY &&
+        tempVectorG.y <= bounds.maxY
+      ) {
+        handlesInRect.push(handle);
+      }
+    }
+    if (handlesInRect.length === 0) {
+      return 0;
+    }
+    this.selectHandles(handlesInRect, options);
+    return handlesInRect.length;
   }
 
   private highlightHandle(handle: HandleDescriptor, active: boolean) {
@@ -422,7 +583,7 @@ export class EditableMeshController {
     handle.object.material = material;
   }
 
-  handlePointer(intersections: Intersection[]) {
+  handlePointer(intersections: Intersection[], event?: PointerEvent) {
     const mode = this.sceneManager.getEditMode();
     if (mode === 'object') {
       return false;
@@ -437,25 +598,29 @@ export class EditableMeshController {
       }
       return false;
     });
+    const toggle = !!(event?.ctrlKey || event?.metaKey);
+    const additive = !!event?.shiftKey && !toggle;
     if (!match) {
-      this.clearHandleHighlights();
-      this.activeHandle = undefined;
-      this.handleControls.visible = false;
-      this.handleControls.detach();
+      if (!additive && !toggle) {
+        this.clearSelection();
+      }
       return false;
     }
 
     const object = match.object as Mesh;
     const handle = this.handles.find((entry) => entry.object === object);
     if (!handle || !handle.object.visible) {
+      if (!additive && !toggle) {
+        this.clearSelection();
+      }
       return false;
     }
 
-    this.clearHandleHighlights();
-    this.highlightHandle(handle, true);
-    this.activeHandle = handle;
-    this.handleControls.visible = true;
-    this.handleControls.attach(handle.object);
+    this.selectHandles([handle], { additive, toggle });
     return true;
+  }
+
+  isTransforming() {
+    return this.dragging;
   }
 }

--- a/src/core/GestureController.ts
+++ b/src/core/GestureController.ts
@@ -9,9 +9,13 @@ export class GestureController {
   readonly controls: OrbitControls;
   private pointerDown = { x: 0, y: 0, time: 0 };
   private pointerMoved = false;
+  private pointerDownButton = 0;
   private defaultPosition: Vector3;
   private box = new Box3();
   private vec = new Vector3();
+  private marqueeActive = false;
+  private marqueeStart = { x: 0, y: 0 };
+  private marqueeElement?: HTMLDivElement;
 
   constructor(
     private rendererManager: RendererManager,
@@ -76,15 +80,44 @@ export class GestureController {
   private onPointerDown = (event: PointerEvent) => {
     this.pointerDown = { x: event.clientX, y: event.clientY, time: performance.now() };
     this.pointerMoved = false;
+    this.pointerDownButton = event.button;
+    this.marqueeActive = false;
   };
 
   private onPointerMove = (event: PointerEvent) => {
     if (Math.hypot(event.clientX - this.pointerDown.x, event.clientY - this.pointerDown.y) > 6) {
       this.pointerMoved = true;
     }
+    if (this.marqueeActive) {
+      this.updateMarquee(event);
+      event.preventDefault();
+      return;
+    }
+    if (
+      event.buttons === 1 &&
+      this.pointerDownButton === 0 &&
+      this.sceneManager.getEditMode() !== 'object' &&
+      !this.gizmoManager.isTransforming() &&
+      !this.editableMeshController.isTransforming()
+    ) {
+      const distance = Math.hypot(event.clientX - this.pointerDown.x, event.clientY - this.pointerDown.y);
+      if (distance > 6) {
+        this.beginMarquee(event);
+        this.updateMarquee(event);
+        event.preventDefault();
+      }
+    }
   };
 
   private onPointerUp = (event: PointerEvent) => {
+    if (this.marqueeActive) {
+      const selected = this.completeMarqueeSelection(event);
+      if (selected === 0 && this.sceneManager.getEditMode() !== 'object') {
+        const intersections = this.rendererManager.pick(event.clientX, event.clientY);
+        this.editableMeshController.handlePointer(intersections, event);
+      }
+      return;
+    }
     if (this.gizmoManager.isTransforming()) {
       return;
     }
@@ -93,7 +126,7 @@ export class GestureController {
     if (elapsed < 300 && distance < 6 && !this.pointerMoved) {
       const intersections = this.rendererManager.pick(event.clientX, event.clientY);
       if (this.sceneManager.getEditMode() !== 'object') {
-        this.editableMeshController.handlePointer(intersections);
+        this.editableMeshController.handlePointer(intersections, event);
         return;
       }
       const hit = intersections.find((intersection) => intersection.object.visible && intersection.object instanceof Mesh);
@@ -106,4 +139,105 @@ export class GestureController {
       }
     }
   };
+
+  private beginMarquee(event: PointerEvent) {
+    const element = this.ensureMarqueeElement();
+    if (!element) {
+      this.marqueeActive = false;
+      return;
+    }
+    this.marqueeActive = true;
+    this.marqueeStart = { x: this.pointerDown.x, y: this.pointerDown.y };
+    element.style.display = 'block';
+    element.style.left = '0px';
+    element.style.top = '0px';
+    element.style.width = '0px';
+    element.style.height = '0px';
+    this.controls.enabled = false;
+    event.preventDefault();
+  }
+
+  private updateMarquee(event: PointerEvent) {
+    if (!this.marqueeActive) return;
+    const element = this.ensureMarqueeElement();
+    if (!element) return;
+    const container = element.parentElement;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const startX = this.marqueeStart.x;
+    const startY = this.marqueeStart.y;
+    const currentX = event.clientX;
+    const currentY = event.clientY;
+    const left = Math.min(startX, currentX) - rect.left;
+    const top = Math.min(startY, currentY) - rect.top;
+    const width = Math.abs(currentX - startX);
+    const height = Math.abs(currentY - startY);
+    element.style.left = `${left}px`;
+    element.style.top = `${top}px`;
+    element.style.width = `${width}px`;
+    element.style.height = `${height}px`;
+  }
+
+  private completeMarqueeSelection(event: PointerEvent) {
+    const toggle = !!(event.ctrlKey || event.metaKey);
+    const additive = !!event.shiftKey && !toggle;
+    const domRect = this.rendererManager.domElement.getBoundingClientRect();
+    if (domRect.width === 0 || domRect.height === 0) {
+      this.hideMarquee();
+      this.marqueeActive = false;
+      this.controls.enabled = true;
+      return 0;
+    }
+    const convert = (clientX: number, clientY: number) => ({
+      x: ((clientX - domRect.left) / domRect.width) * 2 - 1,
+      y: -((clientY - domRect.top) / domRect.height) * 2 + 1
+    });
+    const a = convert(this.marqueeStart.x, this.marqueeStart.y);
+    const b = convert(event.clientX, event.clientY);
+    const bounds = {
+      minX: Math.min(a.x, b.x),
+      maxX: Math.max(a.x, b.x),
+      minY: Math.min(a.y, b.y),
+      maxY: Math.max(a.y, b.y)
+    };
+    const count =
+      this.sceneManager.getEditMode() === 'object'
+        ? 0
+        : this.editableMeshController.selectHandlesInRect(bounds, { additive, toggle });
+    this.hideMarquee();
+    this.marqueeActive = false;
+    this.controls.enabled = true;
+    return count;
+  }
+
+  private ensureMarqueeElement(): HTMLDivElement | null {
+    if (this.marqueeElement) {
+      return this.marqueeElement;
+    }
+    const container = this.rendererManager.getContainer();
+    if (!container) {
+      return null;
+    }
+    const computed = window.getComputedStyle(container);
+    if (computed.position === 'static') {
+      container.style.position = 'relative';
+    }
+    const element = document.createElement('div');
+    element.style.position = 'absolute';
+    element.style.border = '1px solid rgba(59, 130, 246, 0.9)';
+    element.style.background = 'rgba(59, 130, 246, 0.2)';
+    element.style.pointerEvents = 'none';
+    element.style.display = 'none';
+    element.style.zIndex = '10';
+    container.appendChild(element);
+    this.marqueeElement = element;
+    return element;
+  }
+
+  private hideMarquee() {
+    if (!this.marqueeElement) return;
+    this.marqueeElement.style.display = 'none';
+    this.marqueeElement.style.width = '0px';
+    this.marqueeElement.style.height = '0px';
+  }
 }

--- a/src/core/RendererManager.ts
+++ b/src/core/RendererManager.ts
@@ -34,6 +34,10 @@ export class RendererManager {
     this.start();
   }
 
+  getContainer(): HTMLElement | null {
+    return this.container ?? this.renderer.domElement.parentElement ?? null;
+  }
+
   unmount() {
     this.stop();
     this.renderer.dispose();

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -16,6 +16,7 @@ declare module "three" {
     length(): number;
     lengthSq(): number;
     copy(vector: Vector3): this;
+    project(camera: PerspectiveCamera): this;
   }
 
   export class Vector2 {
@@ -44,11 +45,13 @@ declare module "three" {
     add(...objects: Object3D[]): this;
     removeFromParent(): void;
     clear(): void;
+    getWorldPosition(target: Vector3): Vector3;
   }
 
   export class Group extends Object3D {}
 
   export class Quaternion {
+    set(x: number, y: number, z: number, w: number): this;
     setFromUnitVectors(from: Vector3, to: Vector3): this;
     copy(quaternion: Quaternion): this;
   }


### PR DESCRIPTION
## Summary
- support multi-handle selections with shared transform pivoting in the editable mesh controller
- add marquee drag detection with an overlay rectangle and normalized selection bounds
- expose the renderer container for overlays, extend the local three.js type stubs, and document manual drag-selection testing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3dfc16dbc8327b10c2047ee8aaccb