### PR TITLE
Remove stray branch markers from editable mesh controller

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -47,10 +47,7 @@ declare module "three" {
     add(...objects: Object3D[]): this;
     removeFromParent(): void;
     clear(): void;
-codex/remove-stray-markers-from-typescript-definitions
-
     getWorldPosition(target: Vector3): Vector3;
-main
     updateMatrixWorld(force?: boolean): void;
     localToWorld(vector: Vector3): Vector3;
     worldToLocal(vector: Vector3): Vector3;


### PR DESCRIPTION
## Summary
- remove stray branch markers and restore balanced control flow in EditableMeshController
- ensure selection and handle transforms update references correctly after edits
- clean stray marker artifacts from three type definitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3eae48f0483278e6c0fc21eb21ea2