### PR TITLE
Remove stray markers from EditableMeshController

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -429,25 +429,10 @@ export class EditableMeshController {
         return;
       }
 
-codex/remove-stray-branch-markers-from-editablemeshcontroller
       if (deltaLocal.lengthSq() === 0) {
         this.transformReference.copy(targetWorld);
         return;
       }
-
-    for (const index of affectedIndices) {
-      positionAttr.setXYZ(
-        index,
-        positionAttr.getX(index) + deltaLocal.x,
-        positionAttr.getY(index) + deltaLocal.y,
-        positionAttr.getZ(index) + deltaLocal.z
-      );
-    }
-
-    if (this.transformTarget === this.selectionPivot) {
-      const delta = tempVector.copy(this.transformTarget.position).sub(this.transformReference);
-      if (delta.lengthSq() === 0) return;
-main
 
       const geometry = mesh.geometry as BufferGeometry;
       const positionAttr = geometry.getAttribute('position') as BufferAttribute;
@@ -510,10 +495,6 @@ main
       const y = positionAttr.getY(index) + delta.y;
       const z = positionAttr.getZ(index) + delta.z;
       positionAttr.setXYZ(index, x, y, z);
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-main
     }
 
     positionAttr.needsUpdate = true;
@@ -525,26 +506,18 @@ main
       this.updateSelectionPivot(handles);
       this.transformReference.copy(this.selectionPivot.position);
     } else {
-codex/remove-stray-branch-markers-from-editablemeshcontroller
       this.transformReference.copy(worldPosition);
 
-      const activeHandle = this.handles.find((handle) => handle.object === this.transformTarget);
+      const activeHandle = this.handles.find((entry) => entry.object === this.transformTarget);
       if (activeHandle) {
         this.transformReference.copy(activeHandle.referencePositionWorld);
-      } else {
-        this.transformReference.copy(worldPosition);
       }
-main
     }
 
     handle.referencePositionLocal.copy(localPosition);
     handle.referencePositionWorld.copy(worldPosition);
     handle.object.position.copy(localPosition);
     this.updateRelatedHandles(handle);
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-main
   }
 
   private commitSelectionEdit() {
@@ -622,12 +595,6 @@ main
       this.handleControls.visible = true;
       this.transformTarget = handle.object;
       this.transformReference.copy(handle.referencePositionWorld);
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-      this.transformReference.copy(handle.referencePositionLocal);
-
-main
       this.activeHandle = handle;
       const worldPosition = handle.object.getWorldPosition(tempVector);
       const misalignment = worldPosition.clone().sub(handle.referencePositionWorld).length();
@@ -699,12 +666,6 @@ main
         lastAdded = handle;
       }
     }
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-
-
-main
     if (lastAdded) {
       this.activeHandle = lastAdded;
     } else if (this.activeHandle && !this.selectedHandles.has(this.activeHandle)) {
@@ -712,12 +673,6 @@ main
     } else if (!this.activeHandle && this.selectedHandles.size > 0) {
       this.activeHandle = this.selectedHandles.values().next().value;
     }
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-
-
-main
     this.updateSelectionState();
   }
 
@@ -766,12 +721,6 @@ main
         }
       }
     }
-codex/remove-stray-branch-markers-from-editablemeshcontroller
-
-
-
-
-main
   }
 
   selectHandlesInRect(bounds: NormalizedSelectionRect, options: SelectionOptions = {}) {


### PR DESCRIPTION
## Summary
- strip stray branch markers from EditableMeshController transform helpers
- restore complete control flow for selection pivot, handle updates, and related handle refreshes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ed9ced088327bf68194600439da8