### PR TITLE
Expand face selection handles to match planar surfaces

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -8,7 +8,6 @@ import {
   MeshBasicMaterial,
   Object3D,
   PerspectiveCamera,
-  PlaneGeometry,
   SphereGeometry,
   BoxGeometry,
   Vector3,
@@ -68,7 +67,6 @@ export class EditableMeshController {
   private dragging = false;
   private vertexGeometry = new SphereGeometry(0.04, 12, 12);
   private edgeGeometry = new BoxGeometry(0.08, 0.08, 0.08);
-  private faceGeometry = new PlaneGeometry(0.18, 0.18);
   private materials = {
     vertex: {
       idle: new MeshBasicMaterial({ color: '#a855f7' }),
@@ -314,12 +312,14 @@ export class EditableMeshController {
       const { centroid, normal } = this.computeFaceGroupAttributes(positionAttr, group.indices);
       const faceWorldPosition = mesh.localToWorld(centroid.clone());
       const worldNormal = this.transformNormalToWorld(normal.clone(), mesh);
-      const faceMesh = new Mesh(this.faceGeometry, this.materials.face.idle);
+      const faceGeometry = this.createFaceHandleGeometry(positionAttr, group.indices, centroid, normal);
+      const faceMesh = new Mesh(faceGeometry, this.materials.face.idle);
       faceMesh.name = `Face ${group.faceIndex}`;
       faceMesh.userData.__handle = true;
       faceMesh.position.copy(centroid);
       tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), normal);
       faceMesh.quaternion.copy(tempQuaternion);
+      faceMesh.renderOrder = 1;
       this.handlesGroup.add(faceMesh);
       this.handles.push({
         object: faceMesh,
@@ -446,6 +446,76 @@ export class EditableMeshController {
     return { centroid, normal };
   }
 
+  private getFacePlaneBasis(normal: Vector3) {
+    const u = new Vector3();
+    const v = new Vector3();
+    if (Math.abs(normal.x) > Math.abs(normal.z)) {
+      u.set(-normal.y, normal.x, 0);
+    } else {
+      u.set(0, -normal.z, normal.y);
+    }
+    if (u.lengthSq() === 0) {
+      u.set(1, 0, 0);
+    }
+    u.normalize();
+    v.crossVectors(normal, u).normalize();
+    return { u, v };
+  }
+
+  private createFaceHandleGeometry(
+    attr: BufferAttribute,
+    indices: number[],
+    centroid: Vector3,
+    normal: Vector3
+  ) {
+    const geometry = new BufferGeometry();
+    const { u, v } = this.getFacePlaneBasis(normal);
+    const positions = new Float32Array(indices.length * 3);
+    for (let i = 0; i < indices.length; i++) {
+      const index = indices[i];
+      this.getVertexPosition(attr, index, tempVector);
+      tempVector.sub(centroid);
+      positions[i * 3] = tempVector.dot(u);
+      positions[i * 3 + 1] = tempVector.dot(v);
+      positions[i * 3 + 2] = 0.001;
+    }
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+    return geometry;
+  }
+
+  private updateFaceHandleGeometry(
+    handle: HandleDescriptor,
+    attr: BufferAttribute,
+    centroid: Vector3,
+    normal: Vector3
+  ) {
+    const mesh = handle.object;
+    let geometry = mesh.geometry as BufferGeometry;
+    const expectedCount = handle.indices.length * 3;
+    const positionAttribute = geometry.getAttribute('position') as BufferAttribute | undefined;
+    if (!positionAttribute || positionAttribute.count * 3 !== expectedCount) {
+      geometry.dispose();
+      geometry = this.createFaceHandleGeometry(attr, handle.indices, centroid, normal);
+      mesh.geometry = geometry;
+      return;
+    }
+    const { u, v } = this.getFacePlaneBasis(normal);
+    const array = positionAttribute.array as Float32Array;
+    for (let i = 0; i < handle.indices.length; i++) {
+      const index = handle.indices[i];
+      this.getVertexPosition(attr, index, tempVector);
+      tempVector.sub(centroid);
+      array[i * 3] = tempVector.dot(u);
+      array[i * 3 + 1] = tempVector.dot(v);
+      array[i * 3 + 2] = 0.001;
+    }
+    positionAttribute.needsUpdate = true;
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+  }
+
   private refreshHandles() {
     if (!this.activeMesh) return;
     const geometry = this.activeMesh.geometry as BufferGeometry;
@@ -476,6 +546,7 @@ export class EditableMeshController {
           const { centroid, normal } = this.computeFaceGroupAttributes(positionAttr, handle.indices);
           const worldPosition = mesh.localToWorld(centroid.clone());
           const worldNormal = this.transformNormalToWorld(normal.clone(), mesh);
+          this.updateFaceHandleGeometry(handle, positionAttr, centroid, normal);
           handle.object.position.copy(centroid);
           handle.referencePositionLocal.copy(centroid);
           handle.referencePositionWorld.copy(worldPosition);
@@ -792,6 +863,7 @@ export class EditableMeshController {
           const { centroid, normal } = this.computeFaceGroupAttributes(positionAttr, handle.indices);
           const worldPosition = mesh.localToWorld(centroid.clone());
           const worldNormal = this.transformNormalToWorld(normal.clone(), mesh);
+          this.updateFaceHandleGeometry(handle, positionAttr, centroid, normal);
           handle.object.position.copy(centroid);
           handle.referencePositionLocal.copy(centroid);
           handle.referencePositionWorld.copy(worldPosition);

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -13,6 +13,8 @@ declare module "three" {
     multiplyScalar(scalar: number): Vector3;
     add(vector: Vector3): Vector3;
     cross(vector: Vector3): Vector3;
+    crossVectors(a: Vector3, b: Vector3): Vector3;
+    dot(vector: Vector3): number;
     length(): number;
     lengthSq(): number;
     copy(vector: Vector3): this;
@@ -111,6 +113,7 @@ declare module "three" {
     geometry: TGeometry;
     castShadow: boolean;
     receiveShadow: boolean;
+    renderOrder: number;
   }
 
   export class MeshBasicMaterial {


### PR DESCRIPTION
## Summary
- rebuild face selection handles using per-face geometries so picking covers entire planar groups
- recalculate handle meshes during refresh/update to stay in sync with edited vertices
- extend local three.js typings with missing Vector3 helpers and Mesh.renderOrder

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e52fa863b48327b21ace60c728b599