### PR TITLE
Fix edge and vertex handle deduplication

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -39,6 +39,8 @@ const tempVectorF = new Vector3();
 const tempQuaternion = new Quaternion();
 const tempVectorG = new Vector3();
 const tempVectorH = new Vector3();
+const tempVectorI = new Vector3();
+const tempVectorJ = new Vector3();
 
 interface NormalizedSelectionRect {
   minX: number;
@@ -53,6 +55,7 @@ interface SelectionOptions {
 }
 
 const tempQuaternionB = new Quaternion();
+const POSITION_KEY_PRECISION = 1e5;
 
 export class EditableMeshController {
   private handlesGroup = new Group();
@@ -241,66 +244,196 @@ export class EditableMeshController {
     const mesh = this.activeMesh;
     mesh.updateMatrixWorld(true);
 
+    const indicesByVertexKey = new Map<string, Set<number>>();
+    const edgeMap = new Map<
+      string,
+      {
+        indices: Set<number>;
+        planeKeys: Set<string>;
+        representatives: Map<string, number>;
+        occurrences: number;
+      }
+    >();
+    const planeGroups = new Map<string, { indices: number[]; faceIndex: number }>();
+    const quantize = (value: number) => Math.round(value * 1000) / 1000;
+    const vertexKeyCache = new Map<number, string>();
+    const positionDedupPrecision = POSITION_KEY_PRECISION;
+    const getVertexKey = (index: number) => {
+      let key = vertexKeyCache.get(index);
+      if (key) return key;
+      this.getVertexPosition(positionAttr, index, tempVector);
+      key =
+        `${Math.round(tempVector.x * positionDedupPrecision) / positionDedupPrecision}|` +
+        `${Math.round(tempVector.y * positionDedupPrecision) / positionDedupPrecision}|` +
+        `${Math.round(tempVector.z * positionDedupPrecision) / positionDedupPrecision}`;
+      vertexKeyCache.set(index, key);
+      let bucket = indicesByVertexKey.get(key);
+      if (!bucket) {
+        bucket = new Set<number>();
+        indicesByVertexKey.set(key, bucket);
+      }
+      bucket.add(index);
+      return key;
+    };
+    let faceCounter = 0;
+
     for (let i = 0; i < vertexCount; i++) {
+      getVertexKey(i);
+    }
+
+    for (let i = 0; i < vertexCount; i += 3) {
+      const tri = [i, i + 1, i + 2];
+      const triVertexKeys = tri.map((index) => getVertexKey(index));
+      for (let e = 0; e < 3; e++) {
+        const a = tri[e];
+        const b = tri[(e + 1) % 3];
+        const keyA = triVertexKeys[e];
+        const keyB = triVertexKeys[(e + 1) % 3];
+        const edgeKey = keyA < keyB ? `${keyA}|${keyB}` : `${keyB}|${keyA}`;
+        let entry = edgeMap.get(edgeKey);
+        if (!entry) {
+          entry = {
+            indices: new Set<number>(),
+            planeKeys: new Set<string>(),
+            representatives: new Map<string, number>(),
+            occurrences: 0
+          };
+          edgeMap.set(edgeKey, entry);
+        }
+        entry.indices.add(a);
+        entry.indices.add(b);
+        entry.occurrences += 1;
+        if (!entry.representatives.has(keyA)) {
+          entry.representatives.set(keyA, a);
+        }
+        if (!entry.representatives.has(keyB)) {
+          entry.representatives.set(keyB, b);
+        }
+      }
+
+      const faceCenter = this.computeFaceCenter(positionAttr, tri[0], tri[1], tri[2]).clone();
+      const faceNormal = this.computeFaceNormal(positionAttr, tri[0], tri[1], tri[2]).clone();
+      if (faceNormal.lengthSq() === 0) {
+        faceNormal.set(0, 0, 1);
+      } else {
+        faceNormal.normalize();
+      }
+
+      const absX = Math.abs(faceNormal.x);
+      const absY = Math.abs(faceNormal.y);
+      const absZ = Math.abs(faceNormal.z);
+      if (absX >= absY && absX >= absZ) {
+        if (faceNormal.x < 0) faceNormal.multiplyScalar(-1);
+      } else if (absY >= absX && absY >= absZ) {
+        if (faceNormal.y < 0) faceNormal.multiplyScalar(-1);
+      } else if (faceNormal.z < 0) {
+        faceNormal.multiplyScalar(-1);
+      }
+
+      const planeConstant =
+        faceNormal.x * faceCenter.x + faceNormal.y * faceCenter.y + faceNormal.z * faceCenter.z;
+      const key =
+        `${quantize(faceNormal.x)}|${quantize(faceNormal.y)}|${quantize(faceNormal.z)}|` +
+        `${quantize(planeConstant)}`;
+
+      let group = planeGroups.get(key);
+      if (!group) {
+        group = {
+          indices: [],
+          faceIndex: faceCounter++
+        };
+        planeGroups.set(key, group);
+      }
+      group.indices.push(...tri);
+
+      for (let e = 0; e < 3; e++) {
+        const a = tri[e];
+        const b = tri[(e + 1) % 3];
+        const keyA = getVertexKey(a);
+        const keyB = getVertexKey(b);
+        const edgeKey = keyA < keyB ? `${keyA}|${keyB}` : `${keyB}|${keyA}`;
+        const entry = edgeMap.get(edgeKey);
+        if (entry) {
+          entry.planeKeys.add(key);
+        }
+      }
+    }
+
+    const vertexEntries = Array.from(indicesByVertexKey.entries()).map(([key, indexSet]) => ({
+      key,
+      indices: Array.from(indexSet).sort((a, b) => a - b)
+    }));
+    vertexEntries.sort((a, b) => a.indices[0] - b.indices[0]);
+
+    for (const entry of vertexEntries) {
       const handleMesh = new Mesh(this.vertexGeometry, this.materials.vertex.idle);
-      handleMesh.name = `Vertex ${i}`;
+      handleMesh.name = `Vertex ${entry.indices.join('-')}`;
       handleMesh.userData.__handle = true;
-      this.getVertexPosition(positionAttr, i, tempVector);
-      const worldPosition = mesh.localToWorld(tempVector.clone());
-      handleMesh.position.copy(tempVector);
+      const localPosition = this.computeIndicesCentroid(positionAttr, entry.indices, tempVectorI);
+      const worldPosition = mesh.localToWorld(tempVectorJ.copy(localPosition));
+      handleMesh.position.copy(localPosition);
       this.handlesGroup.add(handleMesh);
       this.handles.push({
         object: handleMesh,
-        indices: [i],
+        indices: entry.indices.slice(),
         kind: 'vertex',
-        referencePositionLocal: tempVector.clone(),
+        referencePositionLocal: localPosition.clone(),
         referencePositionWorld: worldPosition.clone()
       });
     }
 
-    const edgeMap = new Map<string, { indices: [number, number]; handle?: HandleDescriptor }>();
-    for (let i = 0; i < vertexCount; i += 3) {
-      const tri = [i, i + 1, i + 2];
-      for (let e = 0; e < 3; e++) {
-        const a = tri[e];
-        const b = tri[(e + 1) % 3];
-        const key = a < b ? `${a}|${b}` : `${b}|${a}`;
-        if (!edgeMap.has(key)) {
-          edgeMap.set(key, { indices: [a, b] });
-        }
-      }
-      const facePosition = this.computeFaceCenter(positionAttr, tri[0], tri[1], tri[2]);
-      const faceWorldPosition = mesh.localToWorld(facePosition.clone());
+    for (const group of planeGroups.values()) {
+      const { centroid, normal } = this.computeFaceGroupAttributes(positionAttr, group.indices);
+      const faceWorldPosition = mesh.localToWorld(centroid.clone());
+      const worldNormal = this.transformNormalToWorld(normal.clone(), mesh);
       const faceMesh = new Mesh(this.faceGeometry, this.materials.face.idle);
-      faceMesh.name = `Face ${i / 3}`;
+      faceMesh.name = `Face ${group.faceIndex}`;
       faceMesh.userData.__handle = true;
-      faceMesh.position.copy(facePosition);
-      const localNormal = this.computeFaceNormal(positionAttr, tri[0], tri[1], tri[2]);
-      const worldNormal = this.transformNormalToWorld(localNormal, mesh);
-      tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), localNormal);
+      faceMesh.position.copy(centroid);
+      tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), normal);
       faceMesh.quaternion.copy(tempQuaternion);
       this.handlesGroup.add(faceMesh);
       this.handles.push({
         object: faceMesh,
-        indices: tri.slice(),
+        indices: group.indices.slice(),
         kind: 'face',
-        referencePositionLocal: facePosition.clone(),
+        referencePositionLocal: centroid.clone(),
         referencePositionWorld: faceWorldPosition.clone(),
         normal: worldNormal.clone()
       });
     }
 
-    for (const { indices } of edgeMap.values()) {
-      const position = this.computeEdgeCenter(positionAttr, indices[0], indices[1]);
+    for (const entry of edgeMap.values()) {
+      if (entry.representatives.size !== 2) continue;
+      if (entry.occurrences > 1 && entry.planeKeys.size === 1) {
+        continue;
+      }
+      const vertexKeys = Array.from(entry.representatives.keys());
+      vertexKeys.sort();
+      const representativePairs = vertexKeys
+        .map((key) => entry.representatives.get(key)!)
+        .sort((a, b) => a - b);
+      const indicesSet = new Set<number>();
+      for (const index of entry.indices) {
+        indicesSet.add(index);
+      }
+      for (const key of vertexKeys) {
+        const duplicates = indicesByVertexKey.get(key);
+        if (duplicates) {
+          duplicates.forEach((duplicate) => indicesSet.add(duplicate));
+        }
+      }
+      const handleIndices = Array.from(indicesSet).sort((a, b) => a - b);
+      const position = this.computeEdgeCenter(positionAttr, representativePairs[0], representativePairs[1]);
       const worldPosition = mesh.localToWorld(position.clone());
       const edgeMesh = new Mesh(this.edgeGeometry, this.materials.edge.idle);
       edgeMesh.userData.__handle = true;
-      edgeMesh.name = `Edge ${indices.join('-')}`;
+      edgeMesh.name = `Edge ${handleIndices.join('-')}`;
       edgeMesh.position.copy(position);
       this.handlesGroup.add(edgeMesh);
       this.handles.push({
         object: edgeMesh,
-        indices: indices.slice(),
+        indices: handleIndices,
         kind: 'edge',
         referencePositionLocal: position.clone(),
         referencePositionWorld: worldPosition.clone()
@@ -359,6 +492,52 @@ export class EditableMeshController {
     return normal.clone().applyQuaternion(tempQuaternionB).normalize();
   }
 
+  private computeFaceGroupAttributes(attr: BufferAttribute, indices: number[]): {
+    centroid: Vector3;
+    normal: Vector3;
+  } {
+    const centroid = new Vector3();
+    const normal = new Vector3();
+    const uniqueVertices = new Map<string, Vector3>();
+    const dedupPrecision = POSITION_KEY_PRECISION;
+
+    const quantizeKey = (value: number) => Math.round(value * dedupPrecision) / dedupPrecision;
+
+    for (let i = 0; i < indices.length; i++) {
+      const index = indices[i];
+      this.getVertexPosition(attr, index, tempVector);
+      const key = `${quantizeKey(tempVector.x)}|${quantizeKey(tempVector.y)}|${quantizeKey(tempVector.z)}`;
+      if (!uniqueVertices.has(key)) {
+        uniqueVertices.set(key, tempVector.clone());
+      }
+    }
+
+    if (uniqueVertices.size > 0) {
+      for (const position of uniqueVertices.values()) {
+        centroid.add(position);
+      }
+      centroid.multiplyScalar(1 / uniqueVertices.size);
+    } else if (indices.length >= 3) {
+      this.getVertexPosition(attr, indices[0], centroid);
+    }
+
+    for (let i = 0; i + 2 < indices.length; i += 3) {
+      const a = indices[i];
+      const b = indices[i + 1];
+      const c = indices[i + 2];
+      const triNormal = this.computeFaceNormal(attr, a, b, c);
+      normal.add(triNormal);
+    }
+
+    if (normal.lengthSq() === 0) {
+      normal.set(0, 0, 1);
+    } else {
+      normal.normalize();
+    }
+
+    return { centroid, normal };
+  }
+
   private refreshHandles() {
     if (!this.activeMesh) return;
     const geometry = this.activeMesh.geometry as BufferGeometry;
@@ -366,42 +545,7 @@ export class EditableMeshController {
     const mesh = this.activeMesh;
     mesh.updateMatrixWorld(true);
     for (const handle of this.handles) {
-      switch (handle.kind) {
-        case 'vertex': {
-          const index = handle.indices[0];
-          this.getVertexPosition(positionAttr, index, tempVector);
-          const worldPosition = mesh.localToWorld(tempVector.clone());
-          handle.object.position.copy(tempVector);
-          handle.referencePositionLocal.copy(tempVector);
-          handle.referencePositionWorld.copy(worldPosition);
-          break;
-        }
-        case 'edge': {
-          const [a, b] = handle.indices;
-          const center = this.computeEdgeCenter(positionAttr, a, b);
-          const worldPosition = mesh.localToWorld(center.clone());
-          handle.object.position.copy(center);
-          handle.referencePositionLocal.copy(center);
-          handle.referencePositionWorld.copy(worldPosition);
-          break;
-        }
-        case 'face': {
-          const [a, b, c] = handle.indices;
-          const center = this.computeFaceCenter(positionAttr, a, b, c);
-          const worldPosition = mesh.localToWorld(center.clone());
-          const localNormal = this.computeFaceNormal(positionAttr, a, b, c);
-          const worldNormal = this.transformNormalToWorld(localNormal, mesh);
-          handle.object.position.copy(center);
-          handle.referencePositionLocal.copy(center);
-          handle.referencePositionWorld.copy(worldPosition);
-          if (handle.normal) {
-            handle.normal.copy(worldNormal);
-          }
-          tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), localNormal);
-          handle.object.quaternion.copy(tempQuaternion);
-          break;
-        }
-      }
+      this.updateHandleTransform(handle, positionAttr, mesh);
     }
     this.updateHandleHighlights();
     if (!this.dragging) {
@@ -684,41 +828,89 @@ export class EditableMeshController {
     mesh.updateMatrixWorld(true);
     for (const handle of this.handles) {
       if (handle === active) continue;
-      switch (handle.kind) {
-        case 'vertex': {
-          const index = handle.indices[0];
-          this.getVertexPosition(positionAttr, index, tempVector);
-          const worldPosition = mesh.localToWorld(tempVector.clone());
-          handle.object.position.copy(tempVector);
-          handle.referencePositionLocal.copy(tempVector);
-          handle.referencePositionWorld.copy(worldPosition);
-          break;
+      this.updateHandleTransform(handle, positionAttr, mesh);
+    }
+  }
+
+  private computeIndicesCentroid(
+    attr: BufferAttribute,
+    indices: number[],
+    target = new Vector3()
+  ) {
+    target.set(0, 0, 0);
+    if (indices.length === 0) {
+      return target;
+    }
+    for (const index of indices) {
+      this.getVertexPosition(attr, index, tempVector);
+      target.add(tempVector);
+    }
+    target.multiplyScalar(1 / indices.length);
+    return target;
+  }
+
+  private getEdgeEndpointIndices(attr: BufferAttribute, indices: number[]): [number, number] {
+    const seen = new Map<string, number>();
+    for (const index of indices) {
+      this.getVertexPosition(attr, index, tempVector);
+      const key =
+        `${Math.round(tempVector.x * POSITION_KEY_PRECISION) / POSITION_KEY_PRECISION}|` +
+        `${Math.round(tempVector.y * POSITION_KEY_PRECISION) / POSITION_KEY_PRECISION}|` +
+        `${Math.round(tempVector.z * POSITION_KEY_PRECISION) / POSITION_KEY_PRECISION}`;
+      if (!seen.has(key)) {
+        seen.set(key, index);
+      }
+      if (seen.size === 2) {
+        break;
+      }
+    }
+    const unique = Array.from(seen.values());
+    if (unique.length >= 2) {
+      return [unique[0], unique[1]];
+    }
+    if (indices.length >= 2) {
+      return [indices[0], indices[1]];
+    }
+    const fallback = indices[0] ?? 0;
+    return [fallback, fallback];
+  }
+
+  private updateHandleTransform(
+    handle: HandleDescriptor,
+    attr: BufferAttribute,
+    mesh: Mesh
+  ) {
+    switch (handle.kind) {
+      case 'vertex': {
+        const centroid = this.computeIndicesCentroid(attr, handle.indices, tempVectorI);
+        const worldPosition = mesh.localToWorld(tempVectorJ.copy(centroid));
+        handle.object.position.copy(centroid);
+        handle.referencePositionLocal.copy(centroid);
+        handle.referencePositionWorld.copy(worldPosition);
+        break;
+      }
+      case 'edge': {
+        const [a, b] = this.getEdgeEndpointIndices(attr, handle.indices);
+        const center = this.computeEdgeCenter(attr, a, b);
+        const worldPosition = mesh.localToWorld(tempVectorJ.copy(center));
+        handle.object.position.copy(center);
+        handle.referencePositionLocal.copy(center);
+        handle.referencePositionWorld.copy(worldPosition);
+        break;
+      }
+      case 'face': {
+        const { centroid, normal } = this.computeFaceGroupAttributes(attr, handle.indices);
+        const worldPosition = mesh.localToWorld(centroid.clone());
+        const worldNormal = this.transformNormalToWorld(normal.clone(), mesh);
+        handle.object.position.copy(centroid);
+        handle.referencePositionLocal.copy(centroid);
+        handle.referencePositionWorld.copy(worldPosition);
+        if (handle.normal) {
+          handle.normal.copy(worldNormal);
         }
-        case 'edge': {
-          const [a, b] = handle.indices;
-          const center = this.computeEdgeCenter(positionAttr, a, b);
-          const worldPosition = mesh.localToWorld(center.clone());
-          handle.object.position.copy(center);
-          handle.referencePositionLocal.copy(center);
-          handle.referencePositionWorld.copy(worldPosition);
-          break;
-        }
-        case 'face': {
-          const [a, b, c] = handle.indices;
-          const center = this.computeFaceCenter(positionAttr, a, b, c);
-          const worldPosition = mesh.localToWorld(center.clone());
-          const localNormal = this.computeFaceNormal(positionAttr, a, b, c);
-          const worldNormal = this.transformNormalToWorld(localNormal, mesh);
-          handle.object.position.copy(center);
-          handle.referencePositionLocal.copy(center);
-          handle.referencePositionWorld.copy(worldPosition);
-          if (handle.normal) {
-            handle.normal.copy(worldNormal);
-          }
-          tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), localNormal);
-          handle.object.quaternion.copy(tempQuaternion);
-          break;
-        }
+        tempQuaternion.setFromUnitVectors(new Vector3(0, 0, 1), normal);
+        handle.object.quaternion.copy(tempQuaternion);
+        break;
       }
     }
   }


### PR DESCRIPTION
## Summary
- aggregate vertex and edge handles by deduped vertex positions so moving corners or edges drags every coincident vertex without splitting faces
- centralize handle refresh logic so grouped handles recompute centroids and normals consistently after edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53242d3f08327a826d86198dfef19