### PR TITLE
Hide helper gizmos from scene exports

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -97,6 +97,7 @@ export class EditableMeshController {
     this.handleControls.setMode('translate');
     this.handleControls.setSize(0.7);
     this.handleControls.visible = false;
+    this.handleControls.userData.__helper = true;
     this.handleControls.addEventListener('mouseDown', () => {
       void this.undoStack.capture();
     });
@@ -127,11 +128,13 @@ export class EditableMeshController {
     this.handlesGroup.visible = false;
     this.sceneManager.scene.add(this.handlesGroup);
     this.sceneManager.markPersistent(this.handlesGroup);
+    this.handlesGroup.userData.__helper = true;
 
     this.selectionPivot.name = 'Selection Pivot';
     this.selectionPivot.visible = false;
     this.sceneManager.scene.add(this.selectionPivot);
     this.sceneManager.markPersistent(this.selectionPivot);
+    this.selectionPivot.userData.__helper = true;
 
     this.sceneManager.on('selection', () => this.onSelectionChanged());
     this.sceneManager.on('change', () => this.refreshHandles());


### PR DESCRIPTION
## Summary
- tag transform controls, selection pivot, and the edit handles group as helper objects
- hide helper meshes when exporting or serializing the scene so captures exclude gizmos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68ee8e3048327926f60b22f8c7f28