### PR TITLE
Ensure extruded side-wall clones reseed shared indices

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -911,11 +911,16 @@ export class EditableMeshController {
     const detachedSet = new Set<number>(extrudedVertexSet);
     const seededSharedIndices = new Map<number, number>();
     for (const { source, clone } of clones) {
-      if (extrudedVertexSet.has(clone)) {
+      const cloneIsExtruded = extrudedVertexSet.has(clone);
+      const sourceIsExtruded = extrudedVertexSet.has(source);
+      if (cloneIsExtruded) {
         detachedSet.add(clone);
+        if (sourceIsExtruded) {
+          seededSharedIndices.set(clone, source);
+        }
         continue;
       }
-      if (extrudedVertexSet.has(source)) {
+      if (sourceIsExtruded) {
         detachedSet.add(clone);
         seededSharedIndices.set(clone, source);
         continue;


### PR DESCRIPTION
## Summary
- update face extrusion clone handling to reseed side-wall vertices with their extruded sources

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efcf9c0668832795cf415987c78153