### PR TITLE
Fix seeded shared index handling for extruded vertices

### DIFF
--- a/src/core/EditableMeshController.ts
+++ b/src/core/EditableMeshController.ts
@@ -1006,14 +1006,6 @@ export class EditableMeshController {
     }
 
     for (let i = 0; i < attr.count; i++) {
-      if (detachedSet.has(i)) {
-        const key = `unique:${i}`;
-        this.detachedVertexIndices.add(i);
-        this.vertexIndexToPositionKey.set(i, key);
-        this.positionKeyToIndices.set(key, new Set<number>([i]));
-        continue;
-      }
-
       if (seededSharedIndices?.has(i)) {
         const target = seededSharedIndices.get(i)!;
         let key = this.vertexIndexToPositionKey.get(target);
@@ -1044,6 +1036,14 @@ export class EditableMeshController {
         }
         this.vertexIndexToPositionKey.set(i, key);
         bucket.add(i);
+        continue;
+      }
+
+      if (detachedSet.has(i)) {
+        const key = `unique:${i}`;
+        this.detachedVertexIndices.add(i);
+        this.vertexIndexToPositionKey.set(i, key);
+        this.positionKeyToIndices.set(key, new Set<number>([i]));
         continue;
       }
 


### PR DESCRIPTION
## Summary
- ensure seeded shared indices are processed before the detached guard so extruded clones reuse their shared keys
- retain detached vertex tracking for unique key pairs to keep extrusions separated from originals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f121b28b98832790d86b26fdd3c0f8